### PR TITLE
changes 'HTTP' to 'HTML' in initial help.md page

### DIFF
--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -80,7 +80,7 @@ Currently I support the follwing laguages:
 * Gherken
 * Go
 * Groovy
-* HTTP
+* HTML
 * Java
 * JavaScript
 * Markup (*ML languages such as XML, HTML, etc.)


### PR DESCRIPTION
When opening the app, you display a wonderful help page. I noticed you had HTTP in the list of languages, and I think you meant HTML.  So here's a PR.
