### PR TITLE
Added command line utility.

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -54,6 +54,9 @@
 		1FF207631941CF22005B5654 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF207621941CF22005B5654 /* WebKit.framework */; };
 		1FFF301D1948A5320009AF24 /* MPStringLookupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */; };
 		5318159056384894AA42DB4F /* libPods-MacDownTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AEAF42BBDCEC4012B5092BB3 /* libPods-MacDownTests.a */; };
+		905EF1A9196164CA00FC3CE9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 905EF1A8196164CA00FC3CE9 /* Foundation.framework */; };
+		905EF1AC196164CA00FC3CE9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 905EF1AB196164CA00FC3CE9 /* main.m */; };
+		905EF1B7196164F300FC3CE9 /* macdown in Copy command line utility */ = {isa = PBXBuildFile; fileRef = 905EF1A7196164CA00FC3CE9 /* macdown */; };
 		B49728377A904875B2963C38 /* libPods-MacDown.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C5C1FBBB3ED456285901D31 /* libPods-MacDown.a */; };
 /* End PBXBuildFile section */
 
@@ -72,7 +75,37 @@
 			remoteGlobalIDString = 1F8A836B195348C500B6BF69;
 			remoteInfo = "peg-markdown-highlight";
 		};
+		905EF1B4196164DD00FC3CE9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1FA6DE191941CC9E000409FB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 905EF1A6196164CA00FC3CE9;
+			remoteInfo = "MacDown-cmd";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		905EF1A5196164CA00FC3CE9 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		905EF1B6196164E300FC3CE9 /* Copy command line utility */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = bin;
+			dstSubfolderSpec = 12;
+			files = (
+				905EF1B7196164F300FC3CE9 /* macdown in Copy command line utility */,
+			);
+			name = "Copy command line utility";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1F002A21195B3DAE008B8D93 /* MPRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPRenderer.h; sourceTree = "<group>"; };
@@ -152,6 +185,9 @@
 		1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPStringLookupTests.m; sourceTree = "<group>"; };
 		7C5C1FBBB3ED456285901D31 /* libPods-MacDown.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDown.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F8797E748AA4BCA96DFA790 /* Pods-MacDown.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDown.xcconfig"; path = "Pods/Pods-MacDown.xcconfig"; sourceTree = "<group>"; };
+		905EF1A7196164CA00FC3CE9 /* macdown */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macdown; sourceTree = BUILT_PRODUCTS_DIR; };
+		905EF1A8196164CA00FC3CE9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		905EF1AB196164CA00FC3CE9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		AB3B8954FAB54E3C803DDAEE /* Pods-MacDownTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDownTests.xcconfig"; path = "Pods/Pods-MacDownTests.xcconfig"; sourceTree = "<group>"; };
 		AEAF42BBDCEC4012B5092BB3 /* libPods-MacDownTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDownTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -174,6 +210,14 @@
 				1FA6DE481941CC9E000409FB /* Cocoa.framework in Frameworks */,
 				1FC29F5C1944FC2600D616C7 /* XCTest.framework in Frameworks */,
 				5318159056384894AA42DB4F /* libPods-MacDownTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905EF1A4196164CA00FC3CE9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905EF1A9196164CA00FC3CE9 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -330,6 +374,7 @@
 				1F8A83551953453100B6BF69 /* Dependency */,
 				1FCDC9EB1944F89B00B1F966 /* MacDown */,
 				1FCDCA2F1944F96E00B1F966 /* MacDownTests */,
+				905EF1AA196164CA00FC3CE9 /* MacDown-cmd */,
 				1FA6DE231941CC9E000409FB /* Frameworks */,
 				1FA6DE221941CC9E000409FB /* Products */,
 				7F8797E748AA4BCA96DFA790 /* Pods-MacDown.xcconfig */,
@@ -342,6 +387,7 @@
 			children = (
 				1FA6DE211941CC9E000409FB /* MacDown.app */,
 				1FA6DE451941CC9E000409FB /* MacDownTests.xctest */,
+				905EF1A7196164CA00FC3CE9 /* macdown */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -353,6 +399,7 @@
 				1FC29F5B1944FC2600D616C7 /* XCTest.framework */,
 				1FF207621941CF22005B5654 /* WebKit.framework */,
 				1FA6DE241941CC9E000409FB /* Cocoa.framework */,
+				905EF1A8196164CA00FC3CE9 /* Foundation.framework */,
 				1FA6DE261941CC9E000409FB /* Other Frameworks */,
 				7C5C1FBBB3ED456285901D31 /* libPods-MacDown.a */,
 				AEAF42BBDCEC4012B5092BB3 /* libPods-MacDownTests.a */,
@@ -414,6 +461,14 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		905EF1AA196164CA00FC3CE9 /* MacDown-cmd */ = {
+			isa = PBXGroup;
+			children = (
+				905EF1AB196164CA00FC3CE9 /* main.m */,
+			);
+			path = "MacDown-cmd";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -427,10 +482,12 @@
 				1FA6DE1F1941CC9E000409FB /* Resources */,
 				46C28C219A3C4CCD94797747 /* Copy Pods Resources */,
 				1F8A82A81952F19B00B6BF69 /* Update Build Number */,
+				905EF1B6196164E300FC3CE9 /* Copy command line utility */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				905EF1B5196164DD00FC3CE9 /* PBXTargetDependency */,
 				1FE2197819534A5D00DB931F /* PBXTargetDependency */,
 			);
 			name = MacDown;
@@ -457,6 +514,23 @@
 			productName = MarkPadTests;
 			productReference = 1FA6DE451941CC9E000409FB /* MacDownTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		905EF1A6196164CA00FC3CE9 /* MacDown-cmd */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905EF1B3196164CA00FC3CE9 /* Build configuration list for PBXNativeTarget "MacDown-cmd" */;
+			buildPhases = (
+				905EF1A3196164CA00FC3CE9 /* Sources */,
+				905EF1A4196164CA00FC3CE9 /* Frameworks */,
+				905EF1A5196164CA00FC3CE9 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "MacDown-cmd";
+			productName = "MacDown-cmd";
+			productReference = 905EF1A7196164CA00FC3CE9 /* macdown */;
+			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
@@ -494,6 +568,7 @@
 			targets = (
 				1FA6DE201941CC9E000409FB /* MacDown */,
 				1FA6DE441941CC9E000409FB /* MacDownTests */,
+				905EF1A6196164CA00FC3CE9 /* MacDown-cmd */,
 			);
 		};
 /* End PBXProject section */
@@ -649,6 +724,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		905EF1A3196164CA00FC3CE9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905EF1AC196164CA00FC3CE9 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -661,6 +744,11 @@
 			isa = PBXTargetDependency;
 			name = "peg-markdown-highlight";
 			targetProxy = 1FE2197719534A5D00DB931F /* PBXContainerItemProxy */;
+		};
+		905EF1B5196164DD00FC3CE9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 905EF1A6196164CA00FC3CE9 /* MacDown-cmd */;
+			targetProxy = 905EF1B4196164DD00FC3CE9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -897,6 +985,28 @@
 			};
 			name = Release;
 		};
+		905EF1B1196164CA00FC3CE9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				PRODUCT_NAME = macdown;
+			};
+			name = Debug;
+		};
+		905EF1B2196164CA00FC3CE9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "";
+				PRODUCT_NAME = macdown;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -926,6 +1036,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		905EF1B3196164CA00FC3CE9 /* Build configuration list for PBXNativeTarget "MacDown-cmd" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905EF1B1196164CA00FC3CE9 /* Debug */,
+				905EF1B2196164CA00FC3CE9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -1,0 +1,23 @@
+//
+//  main.m
+//  MacDown-cmd
+//
+//  Created by Esben Sorig on 30/06/2014.
+//  Copyright (c) 2014 Tzu-ping Chung . All rights reserved.
+//
+
+#import <AppKit/AppKit.h>
+
+int main(int argc, const char * argv[])
+{
+    if (argc > 1) {
+        [[NSWorkspace sharedWorkspace] openFile:[NSString stringWithUTF8String:argv[1]]
+                                withApplication:@"MacDown"];
+    }
+    else {
+        [[NSWorkspace sharedWorkspace] launchApplication:@"MacDown"];
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
Added a new target to the project. This is a command line utility
launcher for MacDown. The command line utility allows users to symlink
to their /usr/local/bin folder. In this way users can open files with
MacDown from the command line.

The utility is copied to MacDown.app/Contents/SharedSupport/bin/macdown
