### PR TITLE
Fixed app cannot close after cancel confirmation

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -221,27 +221,37 @@ static NSDictionary *MPEditorKeysToObserve()
 - (void)canCloseDocumentWithDelegate:(id)delegate
                  shouldCloseSelector:(SEL)selector contextInfo:(void *)context
 {
-    // Need to cleanup these so that callbacks won't crash the app.
-    [self.highlighter deactivate];
-    self.highlighter.targetTextView = nil;
-    self.preview.frameLoadDelegate = nil;
-    self.preview.policyDelegate = nil;
-
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center removeObserver:self
-                      name:NSTextDidChangeNotification
-                    object:self.editor];
-    [center removeObserver:self
-                      name:NSUserDefaultsDidChangeNotification
-                    object:[NSUserDefaults standardUserDefaults]];
-    [center removeObserver:self
-                      name:NSViewBoundsDidChangeNotification
-                    object:self.editor.enclosingScrollView.contentView];
-    for (NSString *key in MPEditorKeysToObserve())
-        [self.editor removeObserver:self forKeyPath:key];
-
-    [super canCloseDocumentWithDelegate:delegate shouldCloseSelector:selector
+    [super canCloseDocumentWithDelegate:delegate
+                    shouldCloseSelector:@selector(document:shouldClose:contextInfo:)
                             contextInfo:context];
+}
+
+- (void)document:(NSDocument *)doc shouldClose:(BOOL)shouldClose
+     contextInfo:(void *)contextInfo
+{
+    if (shouldClose)
+    {
+        // Need to cleanup these so that callbacks won't crash the app.
+        [self.highlighter deactivate];
+        self.highlighter.targetTextView = nil;
+        self.preview.frameLoadDelegate = nil;
+        self.preview.policyDelegate = nil;
+        
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center removeObserver:self
+                          name:NSTextDidChangeNotification
+                        object:self.editor];
+        [center removeObserver:self
+                          name:NSUserDefaultsDidChangeNotification
+                        object:[NSUserDefaults standardUserDefaults]];
+        [center removeObserver:self
+                          name:NSViewBoundsDidChangeNotification
+                        object:self.editor.enclosingScrollView.contentView];
+        for (NSString *key in MPEditorKeysToObserve())
+            [self.editor removeObserver:self forKeyPath:key];
+        
+        [self close];
+    }
 }
 
 + (BOOL)autosavesInPlace


### PR DESCRIPTION
Reproduce step is:
1. Open app with new document.
2. Type something
3. Close the windows and cancel the confirmation dialog.
4. Do 3. again, dialog does not appear now and cannot close window also
