### PR TITLE
Fix a endless loop of NSViewBoundsDidChangeNotification handler

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -682,14 +682,19 @@ typedef NS_ENUM(NSUInteger, MPWordCountType) {
 
 - (void)boundsDidChange:(NSNotification *)notification
 {
-    CGFloat clipWidth = [notification.object frame].size.width;
-    NSRect editorFrame = self.editor.frame;
-    if (editorFrame.size.width != clipWidth)
-    {
-        editorFrame.size.width = clipWidth;
-        self.editor.frame = editorFrame;
+    static BOOL shouldHandleNotification = YES;
+    if (shouldHandleNotification) {
+        shouldHandleNotification = NO;
+        CGFloat clipWidth = [notification.object frame].size.width;
+        NSRect editorFrame = self.editor.frame;
+        if (editorFrame.size.width != clipWidth)
+        {
+            editorFrame.size.width = clipWidth;
+            self.editor.frame = editorFrame;
+        }
+        [self syncScrollers];
+        shouldHandleNotification = YES;
     }
-    [self syncScrollers];
 }
 
 


### PR DESCRIPTION
Steps to reproduce：
1. File - Open Recent 
Opens an existing markdown file,
2. Press the "plus" button in upper left corner.

Reason:
In function `-boundsDidChange:` which is an handler of `NSViewBoundsDidChangeNotification`:
`self.editor.frame = editorFrame;`
This will trigger `NSViewBoundsDidChangeNotification` again.
