### PR TITLE
Remove xib settings that seem to crash InterfaceBuilder in 10.8

### DIFF
--- a/MacDown/Localization/Base.lproj/MPDocument.xib
+++ b/MacDown/Localization/Base.lproj/MPDocument.xib
@@ -33,7 +33,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="578"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <customView appearanceType="aqua" id="WJx-Xb-9af">
+                            <customView id="WJx-Xb-9af">
                                 <rect key="frame" x="0.0" y="0.0" width="509" height="578"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <subviews>
@@ -69,7 +69,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
-                                    <popUpButton appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kfG-Fe-ode">
+                                    <popUpButton translatesAutoresizingMaskIntoConstraints="NO" id="kfG-Fe-ode">
                                         <rect key="frame" x="163" y="2" width="184" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <constraints>

--- a/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPGeneralPreferencesViewController.xib
@@ -60,7 +60,7 @@
                                     <binding destination="-2" name="value" keyPath="self.preferences.editorOnRight" id="ACj-cC-Ver"/>
                                 </connections>
                             </button>
-                            <button appearanceType="aqua" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WVd-hz-Dcr">
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WVd-hz-Dcr">
                                 <rect key="frame" x="16" y="9" width="285" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Show word count" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oeW-bF-ybW">


### PR DESCRIPTION
I have no idea how necessary the `appearanceType=“aqua”` properties on some of the IB objects are, but any instance of them seem to set off a 10.8 bug (even on XC 5.1.1) that will crash InterfaceBuilder and also `ibtools` when compiling. I was able to compile only after removing them. If you want MacDown to be build able on 10.8 this seems necessary.

See:
- http://stackoverflow.com/questions/20531240/xcode-5-ibtool-failed-with-exit-code-255
- http://www.tyreeapps.com/blog/tools/2014/06/10/Xcode-Crash-with-xib-Files.html
