### PR TITLE
fixed render on window resizing for nil HighlightTheme or StyleName

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -442,6 +442,7 @@ static hoedown_renderer *MPCreateHTMLRenderer(MPRenderer *renderer)
     else if ([d rendererStyleName:self] != self.styleName &&
              ![[d rendererStyleName:self] isEqualToString:self.styleName])
         changed = YES;
+    
     if (changed)
         [self render];
 }


### PR DESCRIPTION
I made a fix on `renderIfPreferencesChanged` to avoid marking as changed if the `highlightingTheme` or the `rendererStyleName` were nil. This fix is needed because:

```
// If the result of the [d renderererHighlightThemeName:self] return nil
// then the message isEqualToString: over nil will return NO
// the result of this expression will be YES independently of the value of self.highlightThemeName
// so if self.highlightTheme is also nil will return YES being both strings equals to nil
![[d renderererHighlightThemeName:self] isEqualToString:self.highlightThemeName]
```

I made a direct comparison between the stored value and the new one to avoid mark as change if they are both nil. 
