### PR TITLE
Add support for ".markdown" extension

### DIFF
--- a/MacDown/MacDown-Info.plist
+++ b/MacDown/MacDown-Info.plist
@@ -10,6 +10,7 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>md</string>
+				<string>markdown</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
 			<string>MarkdownDocument</string>


### PR DESCRIPTION
Files with `markdown` extension should also have the Markdown file icon.