### PR TITLE
Fix #548

### DIFF
--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -30,12 +30,21 @@ Before I tell you about all the extra syntaxes and capabilities I have, I'll int
 ### Line Breaks
 To force a line break, put two spaces and a newline (return) at the end of the line.
 
-	These lines
-	won't break
+* This two-line bullet 
+won't break
 
-	These lines  
-	will break
+* This two-line bullet  
+will break
 
+Here is the code:
+
+```
+* This two-line bullet 
+won't break
+
+* This two-line bullet  
+will break
+```
 
 ### Strong and Emphasize
 


### PR DESCRIPTION
This is a proposed fix for the line break issue / enhancement #548.  Bullets illustrate the linebreak syntax better than a monospace / code section does.  

This doesn't do anything for visible whitespace or anything like that.  But it does have the non-breaking line with one trailing space as opposed to two for the breaking line.