### PR TITLE
Fixed MASPreferences build error

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target "MacDown" do
   pod 'JJPluralForm', '~> 2.1'      # Plural form localization.
   pod 'LibYAML', '~> 0.1', :inhibit_warnings => true
   pod 'M13OrderedDictionary', '~> 1.1'
-  pod 'MASPreferences', '~> 1.1.3'    # Preference window.
+  pod 'MASPreferences', '~> 1.1.3'  # Preference window.
   pod 'PAPreferences', '~> 0.4'     # Preference singleton (Locked until we drop 10.8 support).
   pod 'Sparkle', '~> 1.13'          # Updater.
 end

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target "MacDown" do
   pod 'JJPluralForm', '~> 2.1'      # Plural form localization.
   pod 'LibYAML', '~> 0.1', :inhibit_warnings => true
   pod 'M13OrderedDictionary', '~> 1.1'
-  pod 'MASPreferences', '~> 1.1'    # Preference window.
+  pod 'MASPreferences', '~> 1.1.3'    # Preference window.
   pod 'PAPreferences', '~> 0.4'     # Preference singleton (Locked until we drop 10.8 support).
   pod 'Sparkle', '~> 1.13'          # Updater.
 end


### PR DESCRIPTION
Got a build error after setting up MacDown here. There’s a bug in MASPreferences 1.1.2 which has been fixed in 1.1.3. Caused build error “-fobjc-arc is not supported on versions of OS X prior to 10.6”. This PR fixes issue #633.