### PR TITLE
Small improvements of macdown-cmd

### DIFF
--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -61,7 +61,8 @@ int main(int argc, const char * argv[])
             NSURL *url;
             
             if ([escaped isAbsolutePath]) {
-                if ([escaped hasPrefix:@"~"]) { // Expand tilde if present
+                // Expand tilde if present
+                if ([escaped hasPrefix:@"~"]) {
                     escaped = [escaped stringByExpandingTildeInPath];
                 }
                 

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -72,6 +72,11 @@ int main(int argc, const char * argv[])
                 url = [NSURL fileURLWithPath:escaped relativeToURL:pwdUrl];
             }
             
+            // Create file if it doesn't exist
+            if (![[NSFileManager defaultManager] fileExistsAtPath:escaped]) {
+                [[NSFileManager defaultManager] createFileAtPath:escaped contents:[NSData new] attributes:nil];
+            }
+            
             [urls addObject:url];
         }
         MPCollectForMacDown(urls);

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -57,8 +57,20 @@ int main(int argc, const char * argv[])
         for (NSString *arg in argproc.arguments)
         {
             NSString *escaped =
-                [arg stringByAddingPercentEscapesUsingEncoding:kMPPathEncoding];
-            NSURL *url = [NSURL URLWithString:escaped relativeToURL:pwdUrl];
+            [arg stringByAddingPercentEscapesUsingEncoding:kMPPathEncoding];
+            NSURL *url;
+            
+            if ([escaped isAbsolutePath]) {
+                if ([escaped hasPrefix:@"~"]) { // Expand tilde if present
+                    escaped = [escaped stringByExpandingTildeInPath];
+                }
+                
+                url = [NSURL fileURLWithPath:escaped];
+            }
+            else {
+                url = [NSURL fileURLWithPath:escaped relativeToURL:pwdUrl];
+            }
+            
             [urls addObject:url];
         }
         MPCollectForMacDown(urls);
@@ -68,4 +80,3 @@ int main(int argc, const char * argv[])
     }
     return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
Made `macdown` properly expand tilde(issue #727) and create file when passing it a path to a file that doesn't exist(issue #728). Is this desired behaviour?

Side note: `macdown` is currently storing paths for files to be opened in user defaults and then launching MacDown.app. This could be done in a cleaner way by passing the URL:s when opening the app with `(BOOL)openURLs: withAppBundleIdentifier: options: additionalEventParamDescriptor: launchIdentifiers:`. Maybe there's good reason for the user defaults implementation. And hey it works! 😊