### PR TITLE
Modified macdown shell utility usage info

### DIFF
--- a/macdown-cmd/MPArgumentProcessor.m
+++ b/macdown-cmd/MPArgumentProcessor.m
@@ -39,7 +39,7 @@
     options.applicationName = ^{ return kMPApplicationName; };
     options.printHelpHeader = ^{
         NSString *fmt =
-            @"usage: %@ version [option] ... file [file ...]\n\nOptions:";
+            @"usage: %@ [file ...]\n\nOptions:";
         return [NSString stringWithFormat:fmt, kMPCommandName];
     };
     [options registerOption:'v' long:kMPVersionKey


### PR DESCRIPTION
Changed to standard format.

Changed from:
```
usage: macdown version [option] ... file [file ...]
```

Into:
```
usage: macdown [file ...]
```