### PR TITLE
Fix logo image URL

### DIFF
--- a/MacDown/Resources/help.md
+++ b/MacDown/Resources/help.md
@@ -1,6 +1,6 @@
 # MacDown
 
-![MacDown logo](http://macdown.uranusjr.com/static/base/img/logo-160.png)
+![MacDown logo](http://macdown.uranusjr.com/static/images/logo-160.png)
 
 Hello there! I’m **MacDown**, the open source Markdown editor for OS X.
 


### PR DESCRIPTION
The URL currently in help.md returns a 404.  I guessed what the URL should be based on the image on the home page, with "-160" added, and it looks like it works.