### PR TITLE
Pipe text to macdown shell utility

### DIFF
--- a/MacDown/Code/Application/MPMainController.h
+++ b/MacDown/Code/Application/MPMainController.h
@@ -11,6 +11,6 @@
 
 @interface MPMainController : NSObject <NSApplicationDelegate>
 
-@property (nonatomic, readonly) MPPreferences *prefereces;
+@property (nonatomic, readonly) MPPreferences *preferences;
 
 @end

--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -99,7 +99,7 @@ NS_INLINE void treat()
 
 @synthesize preferencesWindowController = _preferencesWindowController;
 
-- (MPPreferences *)prefereces
+- (MPPreferences *)preferences
 {
     return [MPPreferences sharedInstance];
 }
@@ -146,7 +146,7 @@ NS_INLINE void treat()
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center addObserver:self selector:@selector(showFirstLaunchTips)
                    name:MPDidDetectFreshInstallationNotification
-                 object:self.prefereces];
+                 object:self.preferences];
     [self copyFiles];
     return self;
 }
@@ -156,9 +156,9 @@ NS_INLINE void treat()
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
 {
-    if (self.prefereces.filesToOpen.count || self.prefereces.pipedContentFileToOpen)
+    if (self.preferences.filesToOpen.count || self.preferences.pipedContentFileToOpen)
         return NO;
-    return !self.prefereces.supressesUntitledDocumentOnLaunch;
+    return !self.preferences.supressesUntitledDocumentOnLaunch;
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
@@ -173,7 +173,7 @@ NS_INLINE void treat()
 
 - (NSString *)feedURLStringForUpdater:(SUUpdater *)updater
 {
-    if (self.prefereces.updateIncludesPreReleases)
+    if (self.preferences.updateIncludesPreReleases)
         return [NSBundle mainBundle].infoDictionary[@"SUBetaFeedURL"];
     return [NSBundle mainBundle].infoDictionary[@"SUFeedURL"];
 }
@@ -222,7 +222,7 @@ NS_INLINE void treat()
 {
     NSDocumentController *c = [NSDocumentController sharedDocumentController];
 
-    for (NSString *path in self.prefereces.filesToOpen)
+    for (NSString *path in self.preferences.filesToOpen)
     {
         NSURL *url = [NSURL fileURLWithPath:path];
         if ([url checkResourceIsReachableAndReturnError:NULL])
@@ -236,15 +236,15 @@ NS_INLINE void treat()
         }
     }
 
-    self.prefereces.filesToOpen = nil;
-    [self.prefereces synchronize];
+    self.preferences.filesToOpen = nil;
+    [self.preferences synchronize];
 }
 
 - (void)openPendingPipedContent {
     NSDocumentController *c = [NSDocumentController sharedDocumentController];
     
-    if (self.prefereces.pipedContentFileToOpen) {
-        NSURL *pipedContentFileToOpenURL = [NSURL fileURLWithPath:self.prefereces.pipedContentFileToOpen];
+    if (self.preferences.pipedContentFileToOpen) {
+        NSURL *pipedContentFileToOpenURL = [NSURL fileURLWithPath:self.preferences.pipedContentFileToOpen];
         NSError *readPipedContentError;
         NSString *pipedContentString = [NSString stringWithContentsOfURL:pipedContentFileToOpenURL encoding:NSUTF8StringEncoding error:&readPipedContentError];
         
@@ -255,8 +255,8 @@ NS_INLINE void treat()
             document.markdown = pipedContentString;
         }
         
-        self.prefereces.pipedContentFileToOpen = nil;
-        [self.prefereces synchronize];
+        self.preferences.pipedContentFileToOpen = nil;
+        [self.preferences synchronize];
     }
 }
 

--- a/MacDown/Code/Preferences/MPPreferences.h
+++ b/MacDown/Code/Preferences/MPPreferences.h
@@ -81,5 +81,6 @@ extern NSString * const MPDidDetectFreshInstallationNotification;
 
 // Convinience methods.
 @property (nonatomic, assign) NSArray *filesToOpen;
+@property (nonatomic, assign) NSString *pipedContentFileToOpen;
 
 @end

--- a/MacDown/Code/Preferences/MPPreferences.m
+++ b/MacDown/Code/Preferences/MPPreferences.m
@@ -182,6 +182,17 @@ static NSString * const kMPDefaultHtmlStyleName = @"GitHub2";
                     inSuiteNamed:kMPApplicationSuiteName];
 }
 
+- (NSString *)pipedContentFileToOpen {
+    return [self.userDefaults objectForKey:kMPPipedContentFileToOpen
+                              inSuiteNamed:kMPApplicationSuiteName];
+}
+
+- (void)setPipedContentFileToOpen:(NSString *)pipedContentFileToOpenPath {
+    [self.userDefaults setObject:pipedContentFileToOpenPath
+                          forKey:kMPPipedContentFileToOpen
+                    inSuiteNamed:kMPApplicationSuiteName];
+}
+
 
 #pragma mark - Private
 

--- a/MacDown/Code/Utility/MPGlobals.h
+++ b/MacDown/Code/Utility/MPGlobals.h
@@ -18,3 +18,4 @@ static NSString * const kMPHelpKey = @"help";
 static NSString * const kMPVersionKey = @"version";
 
 static NSString * const kMPFilesToOpenKey = @"filesToOpenOnNextLaunch";
+static NSString * const kMPPipedContentFileToOpen = @"pipedContentFileToOpenOnNextLaunch";

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -433,7 +433,7 @@
                             <menuItem title="Underline" keyEquivalent="u" id="98U-cK-P7J">
                                 <connections>
                                     <action selector="toggleUnderline:" target="-1" id="Jvi-30-6Gz"/>
-                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.prefereces.extensionUnderline" id="HNG-eA-odB">
+                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.preferences.extensionUnderline" id="HNG-eA-odB">
                                         <dictionary key="options">
                                             <string key="NSValueTransformerName">NSNegateBoolean</string>
                                         </dictionary>
@@ -443,7 +443,7 @@
                             <menuItem title="Strikethrough" keyEquivalent="-" id="9CN-Qi-Fln">
                                 <connections>
                                     <action selector="toggleStrikethrough:" target="-1" id="rUc-gb-x5q"/>
-                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.prefereces.extensionStrikethough" id="kQ0-Wi-BPs">
+                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.preferences.extensionStrikethough" id="kQ0-Wi-BPs">
                                         <dictionary key="options">
                                             <string key="NSValueTransformerName">NSNegateBoolean</string>
                                         </dictionary>
@@ -453,7 +453,7 @@
                             <menuItem title="Highlight" keyEquivalent="=" id="2Os-ij-Aup">
                                 <connections>
                                     <action selector="toggleHighlight:" target="-1" id="Uda-cB-xYx"/>
-                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.prefereces.extensionHighlight" id="9y2-h2-XrX">
+                                    <binding destination="eq0-c4-vgQ" name="hidden" keyPath="self.preferences.extensionHighlight" id="9y2-h2-XrX">
                                         <dictionary key="options">
                                             <string key="NSValueTransformerName">NSNegateBoolean</string>
                                         </dictionary>

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -49,7 +49,7 @@ void MPCollectForMacDown(NSOrderedSet<NSURL *> *urls)
  * 
  * @return Piped data if any, otherwise nil.
  */
-NSData* pipedData() {
+NSData* MPPipedData() {
     NSFileHandle *stdInFileHandle = [NSFileHandle fileHandleWithStandardInput];
     // Check if stdin file handle have anything to read
     // Modified solution from http://stackoverflow.com/questions/7505777/how-do-i-check-for-nsfilehandle-has-data-available
@@ -82,7 +82,7 @@ int main(int argc, const char * argv[])
         else if (argproc.printsVersion)
             [argproc printVersion:YES];
         
-        NSData *dataFromPipe = pipedData();
+        NSData *dataFromPipe = MPPipedData();
         
         if (dataFromPipe) {
             // Store piped content in a temporary file which will be read by MacDown on launch

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -23,6 +23,14 @@ NSRunningApplication *MPRunningMacDownInstance()
     return runningInstances.firstObject;
 }
 
+void MPCollectPipedContentURLForMacDown(NSURL *url) {
+    NSUserDefaults *defaults =
+        [[NSUserDefaults alloc] initWithSuiteNamed:kMPApplicationSuiteName];
+    
+    [defaults setObject:url.path forKey:kMPPipedContentFileToOpen inSuiteNamed:kMPApplicationSuiteName];
+    [defaults synchronize];
+}
+
 void MPCollectForMacDown(NSOrderedSet<NSURL *> *urls)
 {
     NSUserDefaults *defaults =
@@ -36,6 +44,32 @@ void MPCollectForMacDown(NSOrderedSet<NSURL *> *urls)
     [defaults synchronize];
 }
 
+/**
+ * Data piped to macdown through stdin.
+ * 
+ * @return Piped data if any, otherwise nil.
+ */
+NSData* pipedData() {
+    NSFileHandle *stdInFileHandle = [NSFileHandle fileHandleWithStandardInput];
+    // Check if stdin file handle have anything to read
+    // Modified solution from http://stackoverflow.com/questions/7505777/how-do-i-check-for-nsfilehandle-has-data-available
+    int fd = [stdInFileHandle fileDescriptor];
+    fd_set fdset;
+    struct timeval tmout = { 0, 0 };
+    FD_ZERO(&fdset);
+    FD_SET(fd, &fdset);
+    if (select(fd + 1, &fdset, NULL, NULL, &tmout) <= 0) { // Doesn't hold any data
+        return nil;
+    }
+    else if (FD_ISSET(fd, &fdset)) { // Holds data
+        NSData *stdInData = [NSData dataWithData:[stdInFileHandle readDataToEndOfFile]];
+        return stdInData;
+    }
+    else {
+        return nil;
+    }
+}
+
 
 int main(int argc, const char * argv[])
 {
@@ -47,6 +81,16 @@ int main(int argc, const char * argv[])
             [argproc printHelp:YES];
         else if (argproc.printsVersion)
             [argproc printVersion:YES];
+        
+        NSData *dataFromPipe = pipedData();
+        
+        if (dataFromPipe) {
+            // Store piped content in a temporary file which will be read by MacDown on launch
+            NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @"pipedText.txt"];
+            NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
+            [[NSFileManager defaultManager] createFileAtPath:fileURL.path contents:dataFromPipe attributes:nil];
+            MPCollectPipedContentURLForMacDown(fileURL);
+        }
 
         // Treat all arguments as file names to open. Convert them to absolute
         // paths and store them (as an array) in MacDown's user defaults to

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -88,7 +88,10 @@ int main(int argc, const char * argv[])
             // Store piped content in a temporary file which will be read by MacDown on launch
             NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @"pipedText.txt"];
             NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
-            [[NSFileManager defaultManager] createFileAtPath:fileURL.path contents:dataFromPipe attributes:nil];
+            
+            NSError *writeError;
+            [dataFromPipe writeToFile:fileURL.path options:0 error:&writeError];
+            
             MPCollectPipedContentURLForMacDown(fileURL);
         }
 

--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -92,7 +92,9 @@ int main(int argc, const char * argv[])
             NSError *writeError;
             [dataFromPipe writeToFile:fileURL.path options:0 error:&writeError];
             
-            MPCollectPipedContentURLForMacDown(fileURL);
+            if (writeError == nil) {
+                MPCollectPipedContentURLForMacDown(fileURL);
+            }
         }
 
         // Treat all arguments as file names to open. Convert them to absolute


### PR DESCRIPTION
Added support for piping text to the `macdown` shell utility.


Example:
`echo "# My new document" | macdown`

MacDown will open with a new untitled document with the content "# My new document"