### PR TITLE
Disable WebView's cache

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -99,6 +99,25 @@ NS_INLINE void treat()
 
 @synthesize preferencesWindowController = _preferencesWindowController;
 
+- (void)applicationDidFinishLaunching:(NSNotification *)notification
+{
+    // Using private API [WebCache setDisabled:YES] to disable WebView's cache
+    id webCacheClass = (id)NSClassFromString(@"WebCache");
+    if (webCacheClass) {
+// Ignoring "undeclared selector" warning
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+        BOOL setDisabledValue = YES;
+        NSMethodSignature *signature = [webCacheClass methodSignatureForSelector:@selector(setDisabled:)];
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.selector = @selector(setDisabled:);
+        invocation.target = [webCacheClass class];
+        [invocation setArgument:&setDisabledValue atIndex:2];
+        [invocation invoke];
+#pragma clang diagnostic pop
+    }
+}
+
 - (MPPreferences *)preferences
 {
     return [MPPreferences sharedInstance];


### PR DESCRIPTION
Fix #746 image cache issue. Using private API `[WebCache setDisabled:YES]` to disabled the cache of `WebView`. The cache should be disabled, right? Or is there any reason for keeping it enabled?

Feel so so about using private API. Kinda okay since MacDown isn't in the app store. A long term solution is probably what @uranusjr suggested in the #746 comments - migrating to using `WKWebView` instead of `WebView`. That **might** solve this issue as well.

With this fix image will be reloaded when reloading preview or removing and re-adding the image markdown.

_Side note: Another small nice feature might be to trigger a reload of the preview when MacDown enters foreground? Then changes made to images in another application would automatically be updated when returning to MacDown._