### PR TITLE
Trigger preview reload when MacDown become active

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -166,6 +166,11 @@ NS_INLINE void treat()
     [self openPendingPipedContent];
     [self openPendingFiles];
     treat();
+    
+    // Reload preview
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center postNotificationName:MPDidRequestPreviewRenderNotification
+                          object:self];
 }
 
 


### PR DESCRIPTION
Triggering preview to be reloaded when MacDown is active. So that when for example an image has been edited with another application and you go back to MacDown the changes will be visible immediately. This PR depends on the cache issue to be resolved. (PR #747)

Not sure whether this is desired behaviour?