### PR TITLE
Disable show/hide extension in save panel

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -536,6 +536,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (BOOL)prepareSavePanel:(NSSavePanel *)savePanel
 {
     savePanel.extensionHidden = NO;
+    [savePanel setCanSelectHiddenExtension:NO];
+    
     if (self.fileURL && self.fileURL.isFileURL)
     {
         NSString *path = self.fileURL.path;

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -536,7 +536,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (BOOL)prepareSavePanel:(NSSavePanel *)savePanel
 {
     savePanel.extensionHidden = NO;
-    [savePanel setCanSelectHiddenExtension:NO];
+    savePanel.canSelectHiddenExtension = NO;
     
     if (self.fileURL && self.fileURL.isFileURL)
     {


### PR DESCRIPTION
This solves part of the annoyance with #585. There's this checkbox in the save panel for toggling show/hide extension which does nothing. This commit removes that checkbox.