### PR TITLE
Update json to 1.8.6 to support ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
 env:
   global:
     secure: Vyar5YYP3n5CXQWiGxxT2QGYCcZgrSECmMb0BxeaG60KrKfDuXIoj6+rL/VqSImIlaF7qiVHkhHQba8Gf9QHhktUtfK4PQLfE0DzogoFVp8IXaTVEg9wBDnHAiqdadMmY3Vt2blnIIBLiV5+lFWxuSYlX27TTlr1ieev9Z+fMC0=
+before_install:
+- rvm install 2.4.0
+- rvm use 2.4.0
 install:
 - bundle install
 - travis_wait bundle exec pod install

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.1'
 gem 'travis', '~> 1.8', '>= 1.8.6'
-gem 'json', '>= 1.8.6'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.1'
 gem 'travis', '~> 1.8', '>= 1.8.6'
+gem 'json', '>= 1.8.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     gh_inspector (1.0.2)
     highline (1.7.8)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     launchy (2.4.3)
       addressable (~> 2.3)
     minitest (5.10.1)
@@ -106,7 +106,8 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.1)
+  json (>= 1.8.6)
   travis (~> 1.8, >= 1.8.6)
 
 BUNDLED WITH
-   1.13.7
+   1.14.5


### PR DESCRIPTION
`bundle install` fails on ruby 2.4 because version 1.8.3 of the json gem doesn't support it.