### PR TITLE
Added $ to the list of escapable charachters

### DIFF
--- a/Dependency/peg-markdown-highlight/pmh_grammar.leg
+++ b/Dependency/peg-markdown-highlight/pmh_grammar.leg
@@ -407,7 +407,7 @@ Space = Spacechar+
 
 Str = NormalChar (NormalChar | '_'+ &Alphanumeric)*
 
-EscapedChar =   '\\' !Newline [-\\`~|*_{}[\]()#+.!><]
+EscapedChar =   '\\' !Newline [-\\`~|*_{}[\]()#+.!><$]
 
 Entity =    < s:LocMarker
             ( HexEntity | DecEntity | CharEntity ) >


### PR DESCRIPTION
This lets one write \$ to avoid having text between dollar signs marked up as TeX when not intended.