### PR TITLE
fix passing NULL paragraph style

### DIFF
--- a/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.m
+++ b/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.m
@@ -260,7 +260,7 @@ void styleparsing_error_callback(char *error_message, int line_number, void *con
 	[textStorage removeAttribute:NSLinkAttributeName range:range];
     if (self.targetTextView.typingAttributes
         && self.resetTypingAttributes
-        && self.defaultTypingAttributes[NSParagraphStyleAttributeName] != NULL)
+        && self.defaultTypingAttributes[NSParagraphStyleAttributeName])
     {
         [textStorage addAttribute:NSParagraphStyleAttributeName
                             value:self.defaultTypingAttributes[NSParagraphStyleAttributeName]

--- a/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.m
+++ b/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.m
@@ -258,7 +258,9 @@ void styleparsing_error_callback(char *error_message, int line_number, void *con
 	[textStorage applyFontTraits:_clearFontTraitMask range:range];
 	[textStorage removeAttribute:NSBackgroundColorAttributeName range:range];
 	[textStorage removeAttribute:NSLinkAttributeName range:range];
-    if (self.targetTextView.typingAttributes && self.resetTypingAttributes)
+    if (self.targetTextView.typingAttributes
+        && self.resetTypingAttributes
+        && self.defaultTypingAttributes[NSParagraphStyleAttributeName] != NULL)
     {
         [textStorage addAttribute:NSParagraphStyleAttributeName
                             value:self.defaultTypingAttributes[NSParagraphStyleAttributeName]


### PR DESCRIPTION
Does not currently happen in MacDown, but if you play around with
HGMarkdownHighlighter in other projects, you're open to a crash here.