### PR TITLE
Prepare document highlighting in advance

### DIFF
--- a/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.h
+++ b/Dependency/peg-markdown-highlight/HGMarkdownHighlighter.h
@@ -119,11 +119,14 @@ typedef void(^HGStyleParsingErrorCallback)(NSArray *errorMessages);
 - (void) applyStylesFromStylesheet:(NSString *)stylesheet
                   withErrorHandler:(HGStyleParsingErrorCallback)errorHandler;
 
-/** \brief Manually invoke parsing and highlighting of the NSTextView contents. */
+/** \brief Manually invoke parsing and highlighting of the visible NSTextView contents. */
 - (void) parseAndHighlightNow;
 
-/** \brief Manually invoke highlighting (without parsing) of the NSTextView contents. */
+/** \brief Manually invoke highlighting (without parsing) of the visible NSTextView contents. */
 - (void) highlightNow;
+
+/** \brief Manually invoke parsing and highlighting of the entire NSTextView contents, for example to pre-load highlights. */
+- (void) parseAndHighlightWholeDocumentNow;
 
 /** \brief Clear highlighting from the NSTextView.
  * 

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -444,7 +444,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         self.editor.string = self.loadedString;
         self.loadedString = nil;
         [self.renderer parseAndRenderNow];
-        [self.highlighter parseAndHighlightNow];
+        [self.highlighter parseAndHighlightWholeDocumentNow];
     }
 }
 
@@ -1512,6 +1512,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 
     [self.highlighter activate];
+    [self.highlighter parseAndHighlightWholeDocumentNow];
     self.editor.automaticLinkDetectionEnabled = NO;
 }
 


### PR DESCRIPTION
This prevents most of the weirdness when scrolling down and seeing where the highlighter is busy at the moment by pre-processing the whole document once in advance. Only delta updates will still look weird, but most of the visual anchors are where they need to be and delta updates due to background changes don't happen often.