### PR TITLE
Better scroll sync between editor and preview

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1683,8 +1683,10 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     
     // These are the patterns for markdown headers and images respectively. we're only going to
     // handle images that are not inline with other text/images
+    NSRegularExpression *dashRegex = [NSRegularExpression regularExpressionWithPattern:@"^([-]+)$" options:0 error:nil];
     NSRegularExpression *headerRegex = [NSRegularExpression regularExpressionWithPattern:@"^(#+)\\s" options:0 error:nil];
     NSRegularExpression *imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:nil];
+    BOOL previousLineHadContent = NO;
     
     // We start by splitting our document into lines, and then searching
     // line by line for headers or images.
@@ -1692,7 +1694,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     {
         NSString *line = documentLines[lineNumber];
         
-        if ([imgRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] ||
+        if ((previousLineHadContent && [dashRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])]) ||
+            [imgRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] ||
             [headerRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])])
         {
             // Calculate where this header/image appears vertically in the editor
@@ -1713,6 +1716,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
                 maxY = headerY;
             }
         }
+        
+        previousLineHadContent = [line length] && ![dashRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])];
         
         characterCount += [line length] + 1;
     }

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1697,7 +1697,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSInteger relativeHeader = -1; // start of document
     NSInteger characterCount = 0;
 
-    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"^(#+)\\s" options:0 error:nil];
+    NSRegularExpression* hRegex = [NSRegularExpression regularExpressionWithPattern:@"^(#+)\\s" options:0 error:nil];
+    NSRegularExpression* imgRegex = [NSRegularExpression regularExpressionWithPattern:@"!\\[[^\\]]*\\]\\([^)]*\\)" options:0 error:nil];
 
     CGFloat minY = 0;
     CGFloat maxY = 0;
@@ -1708,7 +1709,8 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     for(NSInteger lineNumber = 0;lineNumber < [documentLines count];lineNumber++){
         NSString *line = documentLines[lineNumber];
 
-        if([regex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])]){
+        if([imgRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])] ||
+           [hRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])]){
             NSRange glyphRange = [layoutManager glyphRangeForCharacterRange:NSMakeRange(characterCount, [line length]) actualCharacterRange:nil];
             NSRect topRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:[self.editor textContainer]];
             CGFloat headerY = NSMidY(topRect);
@@ -1739,7 +1741,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 //    self.preview.enclosingScrollView.contentSize.height;
 
-    NSArray<NSNumber*>* headerLocations = [[self.preview.mainFrame.javaScriptContext evaluateScript:@"var arr = Array.prototype.slice.call(document.querySelectorAll(\"h1, h2, h3, h4, h5, h6\")); arr.map(function(n){ return n.getBoundingClientRect().top })"] toArray];
+    NSArray<NSNumber*>* headerLocations = [[self.preview.mainFrame.javaScriptContext evaluateScript:@"var arr = Array.prototype.slice.call(document.querySelectorAll(\"h1, h2, h3, h4, h5, h6, img\")); arr.map(function(n){ return n.getBoundingClientRect().top })"] toArray];
     CGFloat offset = NSMinY(self.preview.enclosingScrollView.contentView.bounds);
 
     CGFloat topHeaderY = 0;

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1739,7 +1739,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     currY = MAX(0, currY - minY);
     maxY -= minY;
     minY -= minY;
-    CGFloat percentScrolledBetweenHeaders = currY / maxY;
+    CGFloat percentScrolledBetweenHeaders = MAX(0, MIN(1.0, currY / maxY));
     
     // Now that we know where the editor position is relative to two reference nodes,
     // we need to find the positions of those nodes in the HTML preview

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1742,6 +1742,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSRegularExpression *headerRegex = [NSRegularExpression regularExpressionWithPattern:@"^(#+)\\s" options:0 error:nil];
     NSRegularExpression *imgRegex = [NSRegularExpression regularExpressionWithPattern:@"^!\\[[^\\]]*\\]\\([^)]*\\)$" options:0 error:nil];
     BOOL previousLineHadContent = NO;
+    
+    CGFloat editorContentHeight = ceilf(NSHeight(self.editor.enclosingScrollView.documentView.bounds));
+    CGFloat editorVisibleHeight = ceilf(NSHeight(self.editor.enclosingScrollView.contentView.bounds));
 
     // We start by splitting our document into lines, and then searching
     // line by line for headers or images.
@@ -1758,7 +1761,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             NSRect topRect = [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:[self.editor textContainer]];
             CGFloat headerY = NSMidY(topRect);
 
-            [locations addObject:@(headerY)];
+            if(headerY <= editorContentHeight - editorVisibleHeight){
+                [locations addObject:@(headerY)];
+            }
         }
         
         previousLineHadContent = [line length] && ![dashRegex numberOfMatchesInString:line options:0 range:NSMakeRange(0, [line length])];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -29,7 +29,7 @@
 #import "MPMathJaxListener.h"
 #import "WebView+WebViewPrivateHeaders.h"
 #import "MPToolbarController.h"
-@import JavaScriptCore;
+#import <JavaScriptCore/JavaScriptCore.h>
 
 static NSString * const kMPDefaultAutosaveName = @"Untitled";
 


### PR DESCRIPTION
This pull request replaces the scrollSync with a new algorithm. The new scroll sync aligns headers and images between the editor pane and the preview pane.

As the user scrolls between two headers, the scroll % between those headers is mirrored in the preview pane. This way, large latex blocks between two headers will scroll faster in the editor than their vertically short preview. Similarly, image tags will scroll much slower in the editor than tall images in the preview pane.

This is related to #21, #287