### PR TITLE
Fix bug of rendering only the first Graphviz image

### DIFF
--- a/MacDown/Resources/Extensions/viz.init.js
+++ b/MacDown/Resources/Extensions/viz.init.js
@@ -13,7 +13,11 @@
       var dom = domAllDot[i];
       var graphSource = dom.innerText || dom.textContent;
 
-      dom.parentElement.parentElement.innerHTML = Viz(graphSource, { engine: engine});
+      try {
+        dom.parentElement.parentElement.innerHTML = Viz(graphSource, {engine: engine});
+      } catch (e) {
+        console.error("Error when parsing node:", dom, e);
+      }
     }
   }
  

--- a/MacDown/Resources/Extensions/viz.init.js
+++ b/MacDown/Resources/Extensions/viz.init.js
@@ -8,17 +8,12 @@
                          "twopi"];
  
   function doGraphviz(engine) {
-    var domAllDot = document.querySelectorAll(".language-" + engine);
+    var domAllDot = document.querySelectorAll("code.language-" + engine);
     for (var i = 0; i < domAllDot.length; i++) {
       var dom = domAllDot[i];
       var graphSource = dom.innerText || dom.textContent;
 
- 
-      dom = dom.parentElement;
-      if (dom.tagName === "PRE") {
-        dom = dom.parentElement;
-      }
-      dom.innerHTML = Viz(graphSource, { engine: engine});
+      dom.parentElement.parentElement.innerHTML = Viz(graphSource, { engine: engine});
     }
   }
  


### PR DESCRIPTION
Assumption:
 - Graphviz images are always in code blocks.
 - Code blocks are constructed as `<code>` in `<pre>`.
 - The `<code>` has `language-*` class.

Fixes #940.