### PR TITLE
css: Improve PDF output

### DIFF
--- a/MacDown/Resources/Styles/Clearness Dark.css
+++ b/MacDown/Resources/Styles/Clearness Dark.css
@@ -154,6 +154,6 @@ kbd {
 		page-break-inside: avoid;
 	}
   body {
-    margin: 2cm 2cm 2cm 2cm; 
+    margin: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/Clearness Dark.css
+++ b/MacDown/Resources/Styles/Clearness Dark.css
@@ -150,9 +150,6 @@ kbd {
     }
 }
 @media print {
-	body,code,pre code,h1,h2,h3,h4,h5,h6 {
-		color: black;
-	}
 	table, pre {
 		page-break-inside: avoid;
 	}

--- a/MacDown/Resources/Styles/Clearness Dark.css
+++ b/MacDown/Resources/Styles/Clearness Dark.css
@@ -156,4 +156,7 @@ kbd {
 	table, pre {
 		page-break-inside: avoid;
 	}
+  body {
+    margin: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/Clearness.css
+++ b/MacDown/Resources/Styles/Clearness.css
@@ -151,9 +151,6 @@ kbd {
     }
 }
 @media print {
-	body,code,pre code,h1,h2,h3,h4,h5,h6 {
-		color: black;
-	}
 	table, pre {
 		page-break-inside: avoid;
 	}

--- a/MacDown/Resources/Styles/Clearness.css
+++ b/MacDown/Resources/Styles/Clearness.css
@@ -157,4 +157,7 @@ kbd {
 	table, pre {
 		page-break-inside: avoid;
 	}
+  body {
+    margin: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/Clearness.css
+++ b/MacDown/Resources/Styles/Clearness.css
@@ -155,6 +155,6 @@ kbd {
 		page-break-inside: avoid;
 	}
   body {
-    margin: 2cm 2cm 2cm 2cm; 
+    margin: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/GitHub.css
+++ b/MacDown/Resources/Styles/GitHub.css
@@ -91,6 +91,6 @@ kbd {
 		word-wrap: break-word;
 	}
   body {
-    padding: 2cm 2cm 2cm 2cm; 
+    padding: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/GitHub.css
+++ b/MacDown/Resources/Styles/GitHub.css
@@ -90,4 +90,7 @@ kbd {
 	pre {
 		word-wrap: break-word;
 	}
+  body {
+    padding: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/GitHub2.css
+++ b/MacDown/Resources/Styles/GitHub2.css
@@ -309,4 +309,7 @@ kbd {
 	pre {
 		word-wrap: break-word;
 	}
+  body {
+    padding: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/GitHub2.css
+++ b/MacDown/Resources/Styles/GitHub2.css
@@ -310,6 +310,6 @@ kbd {
 		word-wrap: break-word;
 	}
   body {
-    padding: 2cm 2cm 2cm 2cm; 
+    padding: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Dark).css
+++ b/MacDown/Resources/Styles/Solarized (Dark).css
@@ -191,6 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 2cm 2cm 2cm 2cm; 
+    margin: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Dark).css
+++ b/MacDown/Resources/Styles/Solarized (Dark).css
@@ -196,4 +196,7 @@ kbd {
   * {
     color: #000 !important;
   }
+  body {
+    margin: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/Solarized (Dark).css
+++ b/MacDown/Resources/Styles/Solarized (Dark).css
@@ -191,12 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 0;
-  }
-  * {
-    color: #000 !important;
-  }
-  body {
     margin: 2cm 2cm 2cm 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Light).css
+++ b/MacDown/Resources/Styles/Solarized (Light).css
@@ -191,6 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 2cm 2cm 2cm 2cm; 
+    margin: 2cm; 
   }
 }

--- a/MacDown/Resources/Styles/Solarized (Light).css
+++ b/MacDown/Resources/Styles/Solarized (Light).css
@@ -196,4 +196,7 @@ kbd {
   * {
     color: #000 !important;
   }
+  body {
+    margin: 2cm 2cm 2cm 2cm; 
+  }
 }

--- a/MacDown/Resources/Styles/Solarized (Light).css
+++ b/MacDown/Resources/Styles/Solarized (Light).css
@@ -191,12 +191,6 @@ kbd {
 
 @media print {
   body {
-    margin: 0;
-  }
-  * {
-    color: #000 !important;
-  }
-  body {
     margin: 2cm 2cm 2cm 2cm; 
   }
 }


### PR DESCRIPTION
These commits fix both #948 and #949 so that the PDF output is more predicable for users. This is only a tiny change, but should make a bigger change in improving user experience (particularly for non-technical users). 

I've attached a copy of the changes from the old output and the new (via the Clearness stylesheet) compared to the preview. Hopefully you can see that the updated version is much more representative of the preview. Since this editor is based on Mou, this change also makes MacDown's PDF output behave in a more similar way.

![old](https://user-images.githubusercontent.com/11884004/38087363-b8962f10-334f-11e8-9620-cb980ad67d6b.png)
![new](https://user-images.githubusercontent.com/11884004/38087373-bdce9896-334f-11e8-83f0-d99af37c2331.png)
![preview](https://user-images.githubusercontent.com/11884004/38087449-fbd15eb2-334f-11e8-97ce-cbb5a068d1cf.png)

There is still the issue of large headers, which is particularly noticeable in PDF outputs with dark backgrounds, e.g. Clearness Dark

![split header](https://user-images.githubusercontent.com/11884004/38087570-841015c0-3350-11e8-9ef2-705b987cf1f2.png)

I believe this issue is being discussed as #359, and it may have something to do with actual PDF generation which is outside the scope of these changes (changing CSS didn't help).

Hopefully this is all good!