### PR TITLE
Add auto-complete support for Guillemets

### DIFF
--- a/MacDown/Code/Extension/NSTextView+Autocomplete.m
+++ b/MacDown/Code/Extension/NSTextView+Autocomplete.m
@@ -15,6 +15,14 @@ static const unichar kMPLeftSingleQuotation  = L'\u2018';
 static const unichar kMPRightSingleQuotation = L'\u2019';
 static const unichar kMPLeftDoubleQuotation  = L'\u201c';
 static const unichar kMPRightDoubleQuotation = L'\u201d';
+static const unichar kMPLeftAngleSingleQuotation  = L'\u2039';
+static const unichar kMPRightAngleSingleQuotation = L'\u203a';
+static const unichar kMPLeftAngleDoubleQuotation  = L'\u00ab';
+static const unichar kMPRightAngleDoubleQuotation = L'\u00bb';
+static const unichar kMPLeftAngleSingleBracket  = L'\u3008';
+static const unichar kMPRightAngleSingleBracket = L'\u3009';
+static const unichar kMPLeftAngleDoubleBracket  = L'\u300a';
+static const unichar kMPRightAngleDoubleBracket = L'\u300b';
 
 static const unichar kMPMatchingCharactersMap[][2] = {
     {L'(', L')'},
@@ -28,6 +36,10 @@ static const unichar kMPMatchingCharactersMap[][2] = {
     {L'\u300e', L'\u300f'},     // white corner brackets
     {kMPLeftSingleQuotation, kMPRightSingleQuotation},
     {kMPLeftDoubleQuotation, kMPRightDoubleQuotation},
+    {kMPLeftAngleSingleQuotation, kMPRightAngleSingleQuotation},    // Latin Single Guillemet
+    {kMPLeftAngleDoubleQuotation, kMPRightAngleDoubleQuotation},    // Latin Double Guillemet
+    {kMPLeftAngleSingleBracket, kMPRightAngleSingleBracket},        // East Asian Single Guillemet
+    {kMPLeftAngleDoubleBracket, kMPRightAngleDoubleBracket},        // East Asian Double Guillemet
     {L'\0', L'\0'},
 };
 


### PR DESCRIPTION
This commit would resolve #939 , adding auto-complete support for both Latin and East Asian Guillemet.

More specifically:
- Typing left Latin double guillemet`«` will be auto-completed as `«»`.
- Same rule applies to Latin single guillemet `‹`, East Asian double guillemet `《` , and East Asian single guillemet `〈 `.

Unicode Links:
1.  [«](https://www.compart.com/en/unicode/U+00AB)[»](https://www.compart.com/en/unicode/U+00BB)
1.  [《](https://www.compart.com/en/unicode/U+300A)[》](https://www.compart.com/en/unicode/U+300B)
1.  [‹](https://www.compart.com/en/unicode/U+2039)[›](https://www.compart.com/en/unicode/U+203A)
1.  [〈](https://www.compart.com/en/unicode/U+3008)[〉](https://www.compart.com/en/unicode/U+3009)



