### PR TITLE
Implemented insertion point placement when opening from a url scheme. Implemented insertion point line highlighting.

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		1FFEB3271972DAB400B2254F /* MPHTMLTabularizeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFEB3261972DAB400B2254F /* MPHTMLTabularizeTests.m */; };
 		1FFEB32B19737D6E00B2254F /* YAMLSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFEB32A19737D6E00B2254F /* YAMLSerialization.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -Wno-unused-variable"; }; };
 		1FFF301D1948A5320009AF24 /* MPStringLookupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */; };
+		28B987B620C3CF6F00121D5A /* NSString+LineOffsets.m in Sources */ = {isa = PBXBuildFile; fileRef = 28B987B520C3CF6F00121D5A /* NSString+LineOffsets.m */; };
+		28B987BA20C494A900121D5A /* MPEditorView+LineHightlight.m in Sources */ = {isa = PBXBuildFile; fileRef = 28B987B720C44D6500121D5A /* MPEditorView+LineHightlight.m */; };
 		3028039E1FD84EAC0055B0DA /* contribute.md in Resources */ = {isa = PBXBuildFile; fileRef = 3028039D1FD84EAB0055B0DA /* contribute.md */; };
 		770BB49E962A302D0715A6A5 /* libPods-MacDown.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42F926DD38559C7CEDB6E42F /* libPods-MacDown.a */; };
 		852D523C1E260A6400BA7162 /* MPTerminalPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 852D523A1E260A6400BA7162 /* MPTerminalPreferencesViewController.m */; };
@@ -486,6 +488,10 @@
 		1FFEB32A19737D6E00B2254F /* YAMLSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YAMLSerialization.m; sourceTree = "<group>"; };
 		1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPStringLookupTests.m; sourceTree = "<group>"; };
 		263367245B2D78A42C2F19D7 /* libPods-macdown-cmd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-macdown-cmd.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		28A0D79E20C71A31000C6617 /* MPEditorView+LineHightlight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPEditorView+LineHightlight.h"; sourceTree = "<group>"; };
+		28B987B420C3CF4500121D5A /* NSString+LineOffsets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+LineOffsets.h"; sourceTree = "<group>"; };
+		28B987B520C3CF6F00121D5A /* NSString+LineOffsets.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+LineOffsets.m"; sourceTree = "<group>"; };
+		28B987B720C44D6500121D5A /* MPEditorView+LineHightlight.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPEditorView+LineHightlight.m"; sourceTree = "<group>"; };
 		3028039D1FD84EAB0055B0DA /* contribute.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = contribute.md; path = Resources/contribute.md; sourceTree = "<group>"; };
 		39EFCAE04F60154F0C8C5469 /* Pods-MacDown.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDown.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacDown/Pods-MacDown.release.xcconfig"; sourceTree = "<group>"; };
 		3C949FDE45493AE77DAD9BF4 /* libPods-MacDownTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MacDownTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -545,6 +551,8 @@
 				1F33F2A31A3B56D20001C849 /* NSColor+HTML.m */,
 				1F2649AE1A7406DB00EF6AF3 /* NSDocumentController+Document.h */,
 				1F2649AF1A7406DB00EF6AF3 /* NSDocumentController+Document.m */,
+				28A0D79E20C71A31000C6617 /* MPEditorView+LineHightlight.h */,
+				28B987B720C44D6500121D5A /* MPEditorView+LineHightlight.m */,
 				1F59491C1AB57D87007394CB /* NSJSONSerialization+File.h */,
 				1F59491D1AB57D87007394CB /* NSJSONSerialization+File.m */,
 				1FFEB3231972D88900B2254F /* NSObject+HTMLTabularize.h */,
@@ -553,6 +561,8 @@
 				1F3FC87B1C854E1C000965E1 /* NSPasteboard+Types.m */,
 				1F0D9D5E194AC7CF008E1856 /* NSString+Lookup.h */,
 				1F0D9D5F194AC7CF008E1856 /* NSString+Lookup.m */,
+				28B987B420C3CF4500121D5A /* NSString+LineOffsets.h */,
+				28B987B520C3CF6F00121D5A /* NSString+LineOffsets.m */,
 				1F0D9D60194AC7CF008E1856 /* NSTextView+Autocomplete.h */,
 				1F0D9D61194AC7CF008E1856 /* NSTextView+Autocomplete.m */,
 				1F847BC41DCC9DB600A47385 /* NSUserDefaults+Suite.h */,
@@ -1226,6 +1236,7 @@
 				1F0D9D7A194AC7F7008E1856 /* MPMarkdownPreferencesViewController.m in Sources */,
 				1F0D9D7D194AC7F7008E1856 /* MPPreferencesViewController.m in Sources */,
 				1F33F2A41A3B56D20001C849 /* NSColor+HTML.m in Sources */,
+				28B987BA20C494A900121D5A /* MPEditorView+LineHightlight.m in Sources */,
 				1F5A37141C869C81006E63E7 /* MPPlugInController.m in Sources */,
 				1F0D9D65194AC7CF008E1856 /* NSString+Lookup.m in Sources */,
 				1F3FC87C1C854E1C000965E1 /* NSPasteboard+Types.m in Sources */,
@@ -1239,6 +1250,7 @@
 				1F0D9D7C194AC7F7008E1856 /* MPPreferences.m in Sources */,
 				1F0D9DAF194AC905008E1856 /* main.m in Sources */,
 				1F0D9D66194AC7CF008E1856 /* NSTextView+Autocomplete.m in Sources */,
+				28B987B620C3CF6F00121D5A /* NSString+LineOffsets.m in Sources */,
 				1F59491E1AB57D87007394CB /* NSJSONSerialization+File.m in Sources */,
 				1FFEB32B19737D6E00B2254F /* YAMLSerialization.m in Sources */,
 				1F64CCC9195F5AB900CE619A /* MPAsset.m in Sources */,

--- a/MacDown.xcodeproj/xcshareddata/xcschemes/MacDown.xcscheme
+++ b/MacDown.xcodeproj/xcshareddata/xcschemes/MacDown.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -31,6 +31,7 @@
 #import "WebView+WebViewPrivateHeaders.h"
 #import "MPToolbarController.h"
 #import <JavaScriptCore/JavaScriptCore.h>
+#import "MPEditorView+LineHightlight.h"
 
 static NSString * const kMPDefaultAutosaveName = @"Untitled";
 
@@ -1573,6 +1574,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         if (backgroundCGColor)
             layer.backgroundColor = backgroundCGColor;
         self.editorContainer.layer = layer;
+        [self.editor updateLineHighlightColor];
     }
     
     if ([changedKey isEqualToString:@"editorBaseFontInfo"])

--- a/MacDown/Code/Extension/MPEditorView+LineHightlight.h
+++ b/MacDown/Code/Extension/MPEditorView+LineHightlight.h
@@ -1,0 +1,22 @@
+//
+//  MPEditorView+LineHightlight.h
+//  MacDown
+//
+//  Created by jj on 05/06/2018.
+//  Copyright © 2018 Tzu-ping Chung . All rights reserved.
+//
+#import "MPEditorView.h"
+
+#ifndef MPEditorView_LineHightlight_h
+#define MPEditorView_LineHightlight_h
+
+@interface MPEditorView (LineHighlight)
+
+/**
+ * Updates the line highlight color when the theme is changed.
+ */
+- (void) updateLineHighlightColor;
+
+@end
+
+#endif /* MPEditorView_LineHightlight_h */

--- a/MacDown/Code/Extension/MPEditorView+LineHightlight.m
+++ b/MacDown/Code/Extension/MPEditorView+LineHightlight.m
@@ -1,0 +1,126 @@
+//
+//  MPEditorView+LineHightlight.m
+//  MacDown
+//
+//  Created by jj on 03/06/2018.
+//  Copyright © 2018 Tzu-ping Chung . All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MPEditorView.h"
+#import "MPEditorView+LineHightlight.h"
+
+// <http://www.cocoabuilder.com/archive/cocoa/310689-how-to-highlight-the-current-line-in-nstextview.html>
+@implementation MPEditorView (LineHighlight)
+
+// FIXME: Should be plugged into the Editor's Preferences Pane.
+
+/**
+ * Draws the Editor's view background.
+ *
+ * Used to highlight the insertion point line.
+ *
+ * @param rect the rect to draw in.
+ */
+- (void) drawViewBackgroundInRect:(NSRect)rect
+{
+    [super drawViewBackgroundInRect:rect];
+
+    NSString *string = [self string];
+
+    if (!string || !self.lineHighlightColor) {
+        return;
+    }
+
+    NSRange selectedRange = self.selectedRange;
+//    NSLog(@"%s: string.length: %tu, selectedRange: [%tu, %tu], \"%@\"",
+//          __PRETTY_FUNCTION__,
+//          string.length,
+//          selectedRange.location,
+//          selectedRange.length,
+//          [string substringWithRange:selectedRange]
+//          );
+
+    if (selectedRange.length > 0) {
+        [self setNeedsDisplay:YES];
+        return;
+    }
+    NSLayoutManager *layoutManager = self.layoutManager;
+    NSPoint containerOrigin = self.textContainerOrigin;
+    NSSize containerInset = self.textContainerInset;
+    NSTextContainer * container = self.textContainer;
+    NSRect viewBounds = self.bounds;
+
+    CGFloat lineWidth = viewBounds.size.width - 2 * containerInset.width;
+    NSRect lineRect = NSZeroRect;
+
+    if ([[string substringWithRange:selectedRange] isEqual: @""]) {
+        // This is the case of an empty string or the insertion point at EOL.
+        NSRect glyphRect = [layoutManager boundingRectForGlyphRange:selectedRange
+                                                   inTextContainer:container];
+        lineRect = NSMakeRect(0,
+                              glyphRect.origin.y,
+                              lineWidth,
+                              glyphRect.size.height
+                              );
+    } else {
+        NSRange lineRange = NSMakeRange(0, 0);
+        [layoutManager lineFragmentUsedRectForGlyphAtIndex:selectedRange.location
+                                            effectiveRange:&lineRange];
+        NSRect glyphsRect = [layoutManager
+                      boundingRectForGlyphRange:lineRange
+                                inTextContainer:[self textContainer]
+                                  ];
+        lineRect = NSMakeRect(0,
+                              glyphsRect.origin.y,
+                              lineWidth,
+                              glyphsRect.size.height
+                              );
+    }
+
+    // Convert from view coordinates to container coordinates
+    NSRect viewLineRect = NSOffsetRect(lineRect,
+                                       containerOrigin.x, containerOrigin.y);
+    drawLineHighlight(viewLineRect, self.lineHighlightColor);
+
+}
+
+/**
+ * Draw the insertion point line.
+ *
+ * @param lineRect the rect to draw in.
+ * @param lineHighlightColor the color to use.
+ */
+static void drawLineHighlight(NSRect lineRect, NSColor *lineHighlightColor) {
+
+    if (NSEqualRects(lineRect, NSZeroRect)) {
+        return;
+    }
+
+    lineRect.size.width = lineRect.size.width - 1;
+    [lineHighlightColor set];
+    CGFloat lineWidth = 1.0;
+    NSRect borderRect = NSInsetRect(lineRect, lineWidth / 2, lineWidth / 2);
+    NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:borderRect];
+    borderPath.lineWidth = lineWidth;
+    [borderPath stroke];
+    [borderPath fill];
+    [NSGraphicsContext restoreGraphicsState];
+}
+
+/**
+ * Update the color of the insertion point line highlight.
+ *
+ * Called when the theme is changed.
+ *
+ * @Fixme: Should be linked to the theme colors schemes.
+ */
+- (void) updateLineHighlightColor {
+    NSColor *selectionColor = [self.selectedTextAttributes
+                               objectForKey:NSBackgroundColorAttributeName];
+    NSColor *viewColor = self.backgroundColor;
+    self.lineHighlightColor = [viewColor blendedColorWithFraction:0.25
+                                                          ofColor:selectionColor];
+}
+
+@end

--- a/MacDown/Code/Extension/NSString+LineOffsets.h
+++ b/MacDown/Code/Extension/NSString+LineOffsets.h
@@ -1,0 +1,16 @@
+//
+//  NSString+LineOffsets.h
+//  MacDown
+//
+//  Created by jj on 03/06/2018.
+//  Copyright © 2018 Tzu-ping Chung . All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (LineOffsets)
+
+- (NSArray *)lineOffsets;
+- (NSUInteger)getOffsetOfLineAtLineNumber:(NSUInteger)index;
+
+@end

--- a/MacDown/Code/Extension/NSString+LineOffsets.m
+++ b/MacDown/Code/Extension/NSString+LineOffsets.m
@@ -1,0 +1,43 @@
+//
+//  NSString+LineOffsets.m
+//  MacDown
+//
+//  Created by jj on 03/06/2018.
+//  Copyright © 2018 Tzu-ping Chung . All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@implementation NSString (LineOffsets)
+
+- (NSArray<NSNumber *> *)lineOffsets
+{
+    NSMutableArray<NSNumber *> *offsets = [NSMutableArray array];
+    __block NSUInteger offset = 0;
+    [offsets addObject:@(offset)];    // first line offset.
+
+    [self enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
+        offset = offset + [line length] + 1;
+        [offsets addObject:@(offset)];
+    }];
+    return offsets;
+}
+
+- (NSUInteger)getOffsetOfLineAtLineNumber:(NSUInteger)lineNumber {
+    NSUInteger lineIndex = lineNumber - 1;
+    __block NSUInteger currentIndex = 0;
+    __block NSUInteger offset = 0;
+    if (lineIndex > 0) {
+        [self enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
+            if (currentIndex == lineIndex) {
+                *stop = YES;
+            } else {
+                offset = offset + [line length] + 1;
+                currentIndex++;
+            }
+        }];
+    }
+    return offset;
+}
+
+@end

--- a/MacDown/Code/View/MPEditorView.h
+++ b/MacDown/Code/View/MPEditorView.h
@@ -8,9 +8,33 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface MPEditorView : NSTextView
+@interface MPEditorView : NSTextView <NSTextViewDelegate>
 
 @property BOOL scrollsPastEnd;
+
+/** If set, the insertion point will be placed on that line when file is open.
+ *
+ * @see openUrlSchemeAppleEvent
+ */
+@property (nonatomic, strong) NSNumber *insertionPointLine;
+
+/** If set, the insertion point will be placed on that column when file is open.
+ *
+ * @see openUrlSchemeAppleEvent in MPMainController.
+ */
+@property (nonatomic, strong) NSNumber *insertionPointColumn;
+
+/**
+ * The highlight color of the insertion point line.
+ */
+// FIXME: Should be linked to the theme colors schemes.
+@property (nonatomic, strong) NSColor *lineHighlightColor;
+
 - (NSRect)contentRect;
+
+/**
+ * Places the insertion point at given line and column.
+ */
+- (void)placeInsertionPointAtLine:(NSNumber *)lineNumber column:(NSNumber *)columnNumber;
 
 @end


### PR DESCRIPTION
Added placement of insertion point at line and column when opening a file from the url scheme :
    <x-macdown://open?url=file:///path/to/file.md&line=123&column=45>

Implemented the insertion point line hightlight.
    FIXME: The insertion point line highlight  color could be plugged in the theme. For now its a blend of the editor background color and the editor selected text background color.
    FIXME: The hightlighting of the insertion point line could be an option in the editor preference pane.