### PR TITLE
Paste image or attachments from clipboard

### DIFF
--- a/MacDown.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/MacDown.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1267,7 +1267,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         NSLog(@"%@", paths);
         
         for (NSString *path in paths) {
-            NSString *fileName = [path lastPathComponent];
+            NSString *fileName = [[path lastPathComponent] stringByReplacingOccurrencesOfString:@" " withString:@""];
             NSString *toPath = [attachmentDir stringByAppendingString:fileName];
             NSLog(@"toPath=%@", toPath);
             [fileManager copyItemAtPath:path toPath:toPath error:nil];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -288,7 +288,9 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (BOOL)editorVisible
 {
-    return (self.editorContainer.frame.size.width != 0.0);
+    // fix the problem that the size will not drop to 0.0 when
+    // the editor is with a scrollbar
+    return (self.editorContainer.frame.size.width > 20.0);
 }
 
 - (BOOL)needsHtml

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1251,7 +1251,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (void)pasteAttachment:(NSPasteboard *)pb
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSString *currentDir = [self.currentBaseUrl path];
+    NSString *currentDir = (self.fileURL)? [self.fileURL path] : [self.currentBaseUrl path];
     BOOL isDir;
     [fileManager fileExistsAtPath:currentDir isDirectory: &isDir];
     if (!isDir) currentDir = [currentDir stringByDeletingLastPathComponent];
@@ -1282,7 +1282,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (void)pasteImage:(NSPasteboard *)pb
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSString *currentDir = [self.currentBaseUrl path];
+    NSString *currentDir = (self.fileURL)? [self.fileURL path] : [self.currentBaseUrl path];
     BOOL isDir;
     [fileManager fileExistsAtPath:currentDir isDirectory: &isDir];
     if (!isDir) currentDir = [currentDir stringByDeletingLastPathComponent];

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -139,8 +139,8 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
-                            <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                            <menuItem title="Page Setup…" id="qIS-W8-SiK">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="runPageLayout:" target="-1" id="Din-rz-gC5"/>
                                 </connections>
@@ -371,16 +371,15 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="onf-Mq-Pah"/>
+                            <menuItem title="Left 1:1 Right" keyEquivalent="O" id="hOV-YQ-vzy">
+                                <connections>
+                                    <action selector="setEqualSplit:" target="-1" id="fJH-RN-c01"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Left 1:3 Right" id="VW7-VH-9yl">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="setEditorOneQuarter:" target="-1" id="kyy-J2-6rx"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Left 1:1 Right" keyEquivalent="0" id="hOV-YQ-vzy">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
-                                <connections>
-                                    <action selector="setEqualSplit:" target="-1" id="fJH-RN-c01"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Left 3:1 Right" id="NZX-Ev-sWt">
@@ -389,14 +388,14 @@
                                     <action selector="setEditorThreeQuarters:" target="-1" id="IEv-Wg-wJA"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Hide Preview Pane" keyEquivalent="H" id="T74-vt-YUA">
-                                <connections>
-                                    <action selector="togglePreviewPane:" target="-1" id="03s-kD-O7K"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Hide Editor Pane" keyEquivalent="E" id="wHk-AQ-iOQ">
+                            <menuItem title="Hide Editor Pane" keyEquivalent="L" id="wHk-AQ-iOQ">
                                 <connections>
                                     <action selector="toggleEditorPane:" target="-1" id="BGN-6z-VZN"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Preview Pane" keyEquivalent="P" id="T74-vt-YUA">
+                                <connections>
+                                    <action selector="togglePreviewPane:" target="-1" id="03s-kD-O7K"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="Cux-kV-g5Z"/>

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -180,7 +180,7 @@
                             </menuItem>
                             <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
                                 <connections>
-                                    <action selector="paste:" target="-1" id="UvS-8e-Qdg"/>
+                                    <action selector="handlePaste:" target="-1" id="jrM-xh-npf"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Delete" id="pa3-QI-u2k">


### PR DESCRIPTION
This adds two features I like.
- When pasting an image from clipboard, the image will be saved to file under "<FILE_DIR>/_image/"
- When pasting files, they will be considered as attachments and put into "<FILE_DIR>/_attachment/"

And It will also generate corresponding strings to paste into the editor, like
```
![](./_image/2018-07-21-23-17-57.jpg)
```
or
```
[temp.m](./_attachment/temp.m)
```
<FILE_DIR> means the directory where the current opened file is located. This way all the images and attachments are located within the folder of <FILE_DIR>, together with the markdown file. This is good when we use it to write wiki locally for example, because we can move the wiki repo everywhere without losing the pictures or attachments.

Hope others like this too.