### PR TITLE
Added "Insert Current Date" item in Format menu

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -910,8 +910,6 @@
 				1FA6DE411941CC9E000409FB /* Sources */,
 				1FA6DE421941CC9E000409FB /* Frameworks */,
 				1FA6DE431941CC9E000409FB /* Resources */,
-				9041D3A827C49F34399D813E /* [CP] Embed Pods Frameworks */,
-				DF04CC0F24ACD058236B0705 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -931,7 +929,6 @@
 				905EF1A3196164CA00FC3CE9 /* Sources */,
 				905EF1A4196164CA00FC3CE9 /* Frameworks */,
 				905EF1A5196164CA00FC3CE9 /* Copy Files */,
-				2B0BC8078DAD9D2E3F7D6027 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1055,16 +1052,16 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-MacDown/Pods-MacDown-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-resources.sh",
 				"${PODS_ROOT}/MASPreferences/Framework/en.lproj/MASPreferencesWindow.xib",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MASPreferencesWindow.nib",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MacDown/Pods-MacDown-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1F8A82A81952F19B00B6BF69 /* Update Build Number */ = {
@@ -1095,21 +1092,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "SOURCE=\"$PWD/Dependency/prism\"\nTARGET=\"$PWD/MacDown/Resources/Prism\"\nrm -rf \"$TARGET\"\nmkdir -p \"$TARGET\"\ncp -r \"$SOURCE/components\" \"$TARGET\"\ncp -r \"$SOURCE/themes\" \"$TARGET\"\ncp -r \"$SOURCE/plugins\" \"$TARGET\"\ncp -r \"$SOURCE/components.js\" \"$TARGET\"";
-			showEnvVarsInLog = 0;
-		};
-		2B0BC8078DAD9D2E3F7D6027 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-macdown-cmd/Pods-macdown-cmd-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		655CCD821E310F9767572216 /* [CP] Check Pods Manifest.lock */ = {
@@ -1148,21 +1130,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9041D3A827C49F34399D813E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MacDownTests/Pods-MacDownTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		B4334ECDC0751C835C1600D7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1187,7 +1154,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh",
 				"${PODS_ROOT}/Sparkle/Sparkle.framework",
 				"${PODS_ROOT}/Sparkle/Sparkle.framework.dSYM",
 			);
@@ -1198,22 +1165,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DF04CC0F24ACD058236B0705 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MacDownTests/Pods-MacDownTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E7FD807B2106CA8F0087F0A8 /* Transpile Styles */ = {

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1453,6 +1453,12 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         [self.editor insertText:@"\n\n"];
 }
 
+- (IBAction)insertCurrentDate:(id)sender
+{
+    NSRange range = self.editor.selectedRange;
+    [self.editor insertText: @"yyyy-MM-dd HH:mm:ss" replacementRange:range];
+}
+
 - (IBAction)setEditorOneQuarter:(id)sender
 {
     [self setSplitViewDividerLocation:0.25];

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1456,7 +1456,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 - (IBAction)insertCurrentDate:(id)sender
 {
     NSRange range = self.editor.selectedRange;
-    [self.editor insertText: @"yyyy-MM-dd HH:mm:ss" replacementRange:range];
+    NSDateFormatter* df = [NSDateFormatter new];
+    df.locale = [NSLocale systemLocale];			//	Avoids potential crashes with certain locales and the specific format below
+    df.dateFormat = @"yyyy-MM-dd HH:mm:ss ZZZ";
+    NSDate* now = [NSDate new];
+    [self.editor insertText: [df stringFromDate: now] replacementRange:range];
 }
 
 - (IBAction)setEditorOneQuarter:(id)sender

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -556,6 +556,11 @@
                             <menuItem title="Image" keyEquivalent="I" id="VkR-aw-5AU">
                                 <connections>
                                     <action selector="toggleImage:" target="-1" id="xuX-4U-p9x"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Insert Current Date" keyEquivalent="D" id="DnJ-Zm-4Jb">
+                                <connections>
+                                    <action selector="insertCurrentDate:" target="-1" id="7Av-Ci-R0q"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="New Paragraph" id="zHE-JL-8eu">

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,12 +22,25 @@ DEPENDENCIES:
   - PAPreferences (~> 0.4)
   - Sparkle (~> 1.18)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - GBCli
+    - JJPluralForm
+    - M13OrderedDictionary
+    - MASPreferences
+    - PAPreferences
+    - Sparkle
+  https://github.com/MacDownApp/cocoapods-specs.git:
+    - handlebars-objc
+    - hoedown
+    - LibYAML
+
 SPEC CHECKSUMS:
   GBCli: e5f988fadb68e1e3c01919f134009fed9796fde0
   handlebars-objc: dde09557cfee1dd0f34ab39595bd5eae7e17cb8b
   hoedown: 8141833441f6430686c06bbc5159d7ce615155fb
   JJPluralForm: 9a6235813990a33a63fb3eff457eb2c633af6acd
-  LibYAML: 3af2c5adf3a40dff936d087aa6a77edc10036bc5
+  LibYAML: dee5c31dcab47b168425083c2b0a6baeacdf499e
   M13OrderedDictionary: 6e157fe9c82aa6b3cd7198f5c5c30c7a6834c4a6
   MASPreferences: c08b8622dd17b47da87669e741efd7c92e970e8c
   PAPreferences: 9f0ffb1e67174a0df001af9d3320166ceb9ee6f5
@@ -35,4 +48,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 1c5b20dfe418eb7c8d4ad108b08133a493681f55
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.6.1


### PR DESCRIPTION
This command replaces the current selection with the current time formatted like `2019-04-02 12:54:00 -0700`, using the system locale and the user’s current time zone.

I found myself needing this frequently with front matter to specify a blog post's date.