### PR TITLE
Remove "forest.css" in Mermaid

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -486,11 +486,13 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     if ([delegate rendererHasSyntaxHighlighting:self])
     {
         [stylesheets addObjectsFromArray:self.prismStylesheets];
+        /**
         // mermaid
         if ([delegate rendererHasMermaid:self])
         {
             [stylesheets addObjectsFromArray:self.mermaidStylesheets];
         }
+        */
         
     }
 


### PR DESCRIPTION
在新版本的Mermaid中已经不需要。而加上这个css文件会影响graphviz里面node的样式

---

This is unnecessary in new Mermaid. This CSS file will affect node style in Graphviz.

Closes #1138