### PR TITLE
Solved issue 1156 and issue 1157

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -207,7 +207,6 @@ NS_INLINE BOOL MPAreNilableStringsEqual(NSString *s1, NSString *s2)
 @property (readonly) NSArray *prismStylesheets;
 @property (readonly) NSArray *prismScripts;
 @property (readonly) NSArray *mathjaxScripts;
-@property (readonly) NSArray *mermaidStylesheets;
 @property (readonly) NSArray *mermaidScripts;
 @property (readonly) NSArray *graphvizScripts;
 @property (readonly) NSArray *stylesheets;
@@ -434,16 +433,6 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     return scripts;
 }
 
-- (NSArray *)mermaidStylesheets
-{
-    NSMutableArray *stylesheets = [NSMutableArray array];
-    
-    NSURL *url = MPExtensionURL(@"mermaid.forest", @"css");
-    [stylesheets addObject:[MPStyleSheet CSSWithURL:url]];
-    
-    return stylesheets;
-}
-
 - (NSArray *)mermaidScripts
 {
     // TODO
@@ -486,12 +475,6 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     if ([delegate rendererHasSyntaxHighlighting:self])
     {
         [stylesheets addObjectsFromArray:self.prismStylesheets];
-        // mermaid
-        if ([delegate rendererHasMermaid:self])
-        {
-            [stylesheets addObjectsFromArray:self.mermaidStylesheets];
-        }
-        
     }
 
     if ([delegate rendererCodeBlockAccesory:self] == MPCodeBlockAccessoryCustom)
@@ -678,7 +661,6 @@ NS_INLINE void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
         [scripts addObjectsFromArray:self.prismScripts];
         if ([self.delegate rendererHasMermaid:self])
         {
-            [styles addObjectsFromArray:self.mermaidStylesheets];
             [scripts addObjectsFromArray:self.mermaidScripts];
         }
         if ([self.delegate rendererHasGraphviz:self])

--- a/MacDown/Resources/Extensions/mermaid.init.js
+++ b/MacDown/Resources/Extensions/mermaid.init.js
@@ -3,6 +3,7 @@
 (function () {
 
   mermaid.initialize({
+    theme: 'forest',
     startOnLoad:false,
     flowchart:{
       htmlLabels: false,


### PR DESCRIPTION
1. Remove the related part in MPRenderer.m (instead of only commenting it out). We can easily revert the change if we regret. That's the point for Git.
2. Remove the Mermaid style sheet.
3. Update MacDown/Resources/Extensions/mermaid.init.js accordingly.
4. Set mermaid's theme to forest.
5. issue 1157's problem I don't found.

Test code:
```
gantt
    title A Gantt Diagram
    section Section
    A task           :a1, 2020-03-01, 30d
    Another task     :after a1  , 20d
    section Another
    Task in sec      :2020-03-12  , 12d
    another task      : 24d
```
And render result.

![image](https://user-images.githubusercontent.com/33367355/76498739-6ca7a280-6478-11ea-964b-b33f865bf574.png)
