### PR TITLE
Fix incorrect split view divider location during initalization

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1631,6 +1631,13 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
             || (editorOnRight && subviews[1] == self.preview))
         {
             [self.splitView swapViews];
+
+            // Manually swapping the split ratio. NSDocument wouldn't
+            // magically do this for us since we manipulated the views.
+            if (!changedKey)
+                [self.splitView setDividerLocation:
+                                (1.0 - self.splitView.dividerLocation)];
+
             if (!self.previewVisible && self.previousSplitRatio >= 0.0)
                 self.previousSplitRatio = 1.0 - self.previousSplitRatio;
 


### PR DESCRIPTION
Currently, opening a new window while “Show Editor on the Right” is enabled would lead to incorrect split view divider location. 

Specifically, if the user set the ratio to 1:3 and tries to create a series of new document, the divider ratio would flip between 3:1, 1:3, 3:1, and so forth. Further code trace indicated that we didn't do anything specific to retain the divider location; `NSDocument` automatically stores that state for us. This does not apply to “Editor on the Right” situations though, as we programmatically swapped the two panes during initialization.

This patch would set the ratio straight immediately after manipulating pane orders. Tested with both default and “editor on the right” configuration and should work without regression.