### PR TITLE
Defer copy, export, and print actions after render

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -895,7 +895,14 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     // Update word count
     if (self.preferences.editorShowWordCount)
         [self updateWordCount];
-    
+
+    // Delayed execution of post-render actions
+    if (self.renderCompletionHandler)
+    {
+        self.renderCompletionHandler();
+        self.renderCompletionHandler = nil;
+    }
+
     self.alreadyRenderingInWeb = NO;
 
     if (self.renderToWebPending)


### PR DESCRIPTION
This pull request would fix the issue raised by #817. 

Specifically, it refactors the weirdly-specific “delay copy after rendering” functionality into a general callback handler for copy HTML, export to HTML and PDF, and print document. The application will now wait until the rendered HTML fully loaded in WebView before performing these actions.

Built and tested on macOS 10.14.