### PR TITLE
Calling brew cask install is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Visit the [project site](http://macdown.uranusjr.com/) for more information, or 
 
 [Download](http://macdown.uranusjr.com/download/latest/), unzip, and drag the app to Applications folder. MacDown is also available through [Homebrew Cask](https://caskroom.github.io/):
 
-    brew cask install macdown
+    brew install --cask macdown
 
 ## Screenshot
 


### PR DESCRIPTION
When installing via brew cask install macdown, It shows this warning message : `Calling brew cask install is deprecated! Use brew install [--cask] instead.`

The change was announced in homebrew v2.5.0: https://brew.sh/2020/09/08/homebrew-2.5.0/