### PR TITLE
feat: Initial Universal build support for Apple Silicon

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -1191,12 +1191,10 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MacDown/Pods-MacDown-frameworks.sh",
 				"${PODS_ROOT}/Sparkle/Sparkle.framework",
-				"${PODS_ROOT}/Sparkle/Sparkle.framework.dSYM",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/Sparkle.framework.dSYM",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -117,8 +117,8 @@ static CGFloat itemWidth = 37;
     // Must convert to IMP to let the compiler know about the method definition
     MPDocument *document = self.document;
     IMP imp = [document methodForSelector:selectedItem.action];
-    void (*impFunc)(id) = (void *)imp;
-    impFunc(document);
+    void (*impFunc)(id, SEL, id) = (void *)imp;
+    impFunc(document, NSSelectorFromString(sender.identifier), document);
 }
 
 

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ target "MacDown" do
   pod 'LibYAML', '~> 0.1'
   pod 'M13OrderedDictionary', '~> 1.1'
   pod 'MASPreferences', '~> 1.3'
-  pod 'Sparkle', '~> 1.18', :inhibit_warnings => false
+  pod 'Sparkle', '~> 1.24', :inhibit_warnings => false
 
   # Locked on 0.4.x until we drop 10.8.
   pod 'PAPreferences', '~> 0.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - GBCli (1.1)
-  - handlebars-objc (1.4.5)
+  - handlebars-objc (1.4.6)
   - hoedown (3.0.7):
     - hoedown/standard (= 3.0.7)
   - hoedown/standard (3.0.7)
@@ -9,7 +9,7 @@ PODS:
   - M13OrderedDictionary (1.1.0)
   - MASPreferences (1.3)
   - PAPreferences (0.5)
-  - Sparkle (1.18.1)
+  - Sparkle (1.24.0)
 
 DEPENDENCIES:
   - GBCli (~> 1.1)
@@ -20,7 +20,7 @@ DEPENDENCIES:
   - M13OrderedDictionary (~> 1.1)
   - MASPreferences (~> 1.3)
   - PAPreferences (~> 0.4)
-  - Sparkle (~> 1.18)
+  - Sparkle (~> 1.24)
 
 SPEC REPOS:
   https://github.com/MacDownApp/cocoapods-specs.git:
@@ -37,15 +37,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   GBCli: e5f988fadb68e1e3c01919f134009fed9796fde0
-  handlebars-objc: dde09557cfee1dd0f34ab39595bd5eae7e17cb8b
+  handlebars-objc: 6e29828b009f66a54693c20ef9954198523da7ce
   hoedown: 8141833441f6430686c06bbc5159d7ce615155fb
   JJPluralForm: 9a6235813990a33a63fb3eff457eb2c633af6acd
   LibYAML: dee5c31dcab47b168425083c2b0a6baeacdf499e
   M13OrderedDictionary: 6e157fe9c82aa6b3cd7198f5c5c30c7a6834c4a6
   MASPreferences: c08b8622dd17b47da87669e741efd7c92e970e8c
   PAPreferences: 9f0ffb1e67174a0df001af9d3320166ceb9ee6f5
-  Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
+  Sparkle: 270cd27377bf04e9c128af06e3a22d0f572d6ee3
 
-PODFILE CHECKSUM: e9356b9a2ceafda7889ba385de6e9f2d8b06cba0
+PODFILE CHECKSUM: 8647c11f148b94186ec177db56595ff63603ca5a
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.0


### PR DESCRIPTION
This PR:

1.  Updated the dependencies so that they will run natively on Apple Silicon 
2. Fixed a problem that toolbar buttons will crash the app on Apple Silicon due to different calling conventions of x86_64 and arm64.
3. Fixes #1215

To make a universal build, use Xcode with version > 12 and universal build should be the default target for release.
