### PR TITLE
FIX: French localization.

### DIFF
--- a/MacDown/Localization/fr.lproj/Localizable.strings
+++ b/MacDown/Localization/fr.lproj/Localizable.strings
@@ -8,10 +8,10 @@
 "Blockquote" = "Bloc de citation";
 
 /* (No Comment) */
-"CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ charactère (sans espaces);%@ charactères (sans espaces)";
+"CHARACTERS_NO_SPACES_PLURAL_STRING" = "%@ caractère (sans espaces);%@ caractères (sans espaces)";
 
 /* (No Comment) */
-"CHARACTERS_PLURAL_STRING" = "%@ charactère;%@ charactères";
+"CHARACTERS_PLURAL_STRING" = "%@ caractère;%@ caractères";
 
 /* Comment toolbar button */
 "Comment" = "Commentaire";


### PR DESCRIPTION
Here are fixes for typos in the French localization.
Feel free to edit the commit, get the fix in your own commits, or use a different workflow to correct the typo.

BTW, congrats for your great tool!

Regards.