### PR TITLE
Fixes issue #1104 (Rendering pane flashing)

### DIFF
--- a/MacDown/Code/Application/MPMainController.m
+++ b/MacDown/Code/Application/MPMainController.m
@@ -102,21 +102,6 @@ NS_INLINE void treat()
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    // Using private API [WebCache setDisabled:YES] to disable WebView's cache
-    id webCacheClass = (id)NSClassFromString(@"WebCache");
-    if (webCacheClass) {
-// Ignoring "undeclared selector" warning
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-        BOOL setDisabledValue = YES;
-        NSMethodSignature *signature = [webCacheClass methodSignatureForSelector:@selector(setDisabled:)];
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-        invocation.selector = @selector(setDisabled:);
-        invocation.target = [webCacheClass class];
-        [invocation setArgument:&setDisabledValue atIndex:2];
-        [invocation invoke];
-#pragma clang diagnostic pop
-    }
     [[NSAppleEventManager sharedAppleEventManager]
         setEventHandler:self
             andSelector:@selector(openUrlSchemeAppleEvent:withReplyEvent:)


### PR DESCRIPTION
For issue #747, a change was introduced that uses private API to disable
caching on the preview pane's web view. This was ostensibly to make it
so that if images referenced in the markdown document are changed on
disk, their changes are reflected in the preview pane.

Unfortunately, perhaps due to some underlying changes to WebKit/WebView,
disabling caching will also disable caching for all sorts of other
things like stylesheets and the base html document loaded from disk.
This results in a momentary flash of empty content if one is typing
quickly.

Reverting the changes for #747 resolves the flashing issue, but does
regress the issue regarding images being persistently cached.

However, the flashing issue appears to be bothering more people than the
image issue, so I believe it would be appropriate to temporarily regress
the image caching bug to resolve the flashing bug. Supposedly, a plan
exists to migrate to WKWebView, which would hopefully resolve both of
these issues simultaneously.