### PR TITLE
Added GitHub Tomorrow Style

### DIFF
--- a/MacDown/Resources/Styles/GitHub Tomorrow.css
+++ b/MacDown/Resources/Styles/GitHub Tomorrow.css
@@ -1,0 +1,470 @@
+body {
+    font-family: -apple-system;
+    font-size: 16px;
+    line-height: 1.5;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    color: #cccccc;
+    background-color: #464646;
+    padding: 30px;
+    word-wrap: break-word;
+}
+
+::selection {
+    color: #ffffff;
+    background-color: #2d2d2d;
+}
+
+body > *:first-child {
+    margin-top: 0 !important;
+}
+
+body > *:last-child {
+    margin-bottom: 0 !important;
+}
+
+em {
+    color: #ffcc66;
+    font-style: italic;
+}
+
+strong {
+    color: #f99157;
+    font-style: bold;
+}
+
+em strong,
+strong em {
+	color: #F7915D;
+}
+
+a {
+    color: #99cc99;
+}
+
+a.absent {
+    color: #FF3333;
+}
+
+a.anchor {
+    display: block;
+    padding-left: 30px;
+    margin-left: -30px;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin-top: 24px;
+    margin-bottom: 16px;
+    font-weight: 600;
+    line-height: 1.25;
+    color: #66cccc;
+    padding: 0;
+    -webkit-font-smoothing: antialiased;
+    cursor: text;
+    position: relative;
+}
+
+h1 tt, h1 code,
+h2 tt, h2 code,
+h3 tt, h3 code,
+h4 tt, h4 code,
+h5 tt, h5 code,
+h6 tt, h6 code {
+	color: #999999;
+    padding: 0 .2em;
+    font-size: inherit;
+}
+
+    
+h1 {
+    font-size: 2em;
+    font-weight: 600;
+    margin: .67em 0;
+    padding-bottom: .3em;
+    border-bottom: 1px solid rgba(102,204,204,0.40);
+}
+
+h2 {
+    font-size: 1.5em;
+    font-weight: 600;
+    padding-bottom: .3em;
+    border-bottom: 1px solid rgba(102,204,204,0.40);
+}
+
+h3 {
+    font-size: 1.25em;
+    font-weight: 600;
+}
+
+h4 {
+    font-size: 1em;
+    font-weight: 600;
+}
+
+h5 {
+    font-size: .875em;
+    font-weight: 600;
+}
+
+h6 {
+    font-size: .85em;
+    font-weight: 600;
+}
+
+p, blockquote, ul, ol, dl, li, table, pre {
+    margin: 15px 0;
+}
+
+hr {
+    border-bottom: 1px solid #66cccc;
+    background-color: #999999;
+    height: 4px;
+    padding: 0;
+}
+
+body > h2:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+body > h1:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+body > h1:first-child + h2 {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+body > h3:first-child, body > h4:first-child, body > h5:first-child, body > h6:first-child {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+a:first-child h1, a:first-child h2, a:first-child h3, a:first-child h4, a:first-child h5, a:first-child h6 {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+h1 p, h2 p, h3 p, h4 p, h5 p, h6 p {
+    margin-top: 0;
+}
+
+ul li::before, ul li ul li ul li::before {
+	font-family: "Menlo Regular";
+	list-style-type: '*  ';
+}
+
+ul li ul li::before, ul li ul li ul li ul li::before {
+	font-family: "Menlo Regular";
+	list-style-type: '–  ';
+}
+
+ul li::before,
+ol li::before {
+    color: #6699cc !important;
+}
+
+ul, ol {
+    padding-left: 30px;
+}
+
+li p.first {
+    display: inline-block;
+}
+
+ul :first-child,
+ol :first-child {
+    margin-top: 0;
+}
+
+dl {
+    padding: 0;
+}
+
+dl dt {
+    font-size: 1em;
+    font-weight: 600;
+    font-style: italic;
+    padding: 0;
+    margin-top: 16px;
+}
+
+dl dt:first-child {
+    padding: 0;
+}
+
+dl dt > :first-child {
+    margin-top: 0;
+}
+
+dl dt > :last-child {
+    margin-bottom: 0;
+}
+
+dl dd {
+    margin: 0 0 15px;
+    padding: 0 15px;
+}
+
+dl dd > :first-child {
+    margin-top: 0;
+}
+
+dl dd > :last-child {
+    margin-bottom: 0;
+}
+
+blockquote {
+    border-left: 4px solid #cc99cc;
+    padding: 0 15px;
+    color: #cc99cc;
+}
+
+blockquote > :first-child {
+    margin-top: 0;
+}
+
+blockquote > :last-child {
+    margin-bottom: 0;
+}
+
+table {
+    padding: 0;
+    border-collapse: collapse;
+}
+
+table tr {
+    border-top: 1px solid #999999;
+    background-color: #2d2d2d;
+    margin: 0;
+    padding: 0;
+}
+
+table tr:nth-child(2n) {
+    background-color: #1c1c1c;
+}
+
+table tr th {
+    font-weight: bold;
+    border: 1px solid #999999;
+    margin: 0;
+    padding: 6px 13px;
+}
+
+table tr td {
+    border: 1px solid #999999;
+    margin: 0;
+    padding: 6px 13px;
+}
+
+table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
+}
+
+table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
+}
+
+img {
+    max-width: 100%;
+}
+
+span.frame {
+    display: block;
+    overflow: hidden;
+}
+
+span.frame > span {
+    border: 1px solid #999999;
+    display: block;
+    float: left;
+    overflow: hidden;
+    margin: 13px 0 0;
+    padding: 7px;
+    width: auto;
+}
+
+span.frame span img {
+    display: block;
+    float: left;
+}
+
+span.frame span span {
+    clear: both;
+    color: #cccccc;
+    display: block;
+    padding: 5px 0 0;
+}
+
+span.align-center {
+    display: block;
+    overflow: hidden;
+    clear: both;
+}
+
+span.align-center > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: center;
+}
+
+span.align-center span img {
+    margin: 0 auto;
+    text-align: center;
+}
+
+span.align-right {
+    display: block;
+    overflow: hidden;
+    clear: both;
+}
+
+span.align-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px 0 0;
+    text-align: right;
+}
+
+span.align-right span img {
+    margin: 0;
+    text-align: right;
+}
+
+span.float-left {
+    display: block;
+    margin-right: 13px;
+    overflow: hidden;
+    float: left;
+}
+
+span.float-left span {
+    margin: 13px 0 0;
+}
+
+span.float-right {
+    display: block;
+    margin-left: 13px;
+    overflow: hidden;
+    float: right;
+}
+
+span.float-right > span {
+    display: block;
+    overflow: hidden;
+    margin: 13px auto 0;
+    text-align: right;
+}
+
+code, tt {
+    color: #999999;
+    background-color: #2D2D2D;
+    font-family: "SF Mono";
+    padding: .2em .4em;
+    margin: 0;
+    font-size: 85%;
+    border-radius: 6px;
+    white-space: nowrap;
+    border-radius: 6px;
+}
+
+a code,
+a tt {
+    color: #99cc99;
+	text-decoration: none;
+}
+
+pre code {
+    font-size: 100%;
+    margin: 0;
+    padding: 0;
+    white-space: pre;
+    border: none;
+    background: transparent;
+}
+
+.highlight {
+    margin-bottom: 16px;
+}
+
+.highlight pre {
+    font-size: 85%;
+    line-height: 1.45;
+    overflow: auto;
+    padding: 16px;
+    border-radius: 6px;
+}
+
+pre {
+    background-color: #404040;
+    font-size: 85%;
+    line-height: 1.45;
+    overflow: auto;
+    padding: 16px;
+    border-radius: 6px;
+}
+
+pre code, pre tt {
+    background-color: transparent;
+    border: none;
+}
+
+sup {
+    font-size: 0.83em;
+    vertical-align: super;
+    line-height: 0;
+}
+
+sup>a::before {
+    content: "[";
+}
+
+sup>a::after {
+    content: "]";
+}
+
+kbd {
+    display: inline-block;
+    padding: 3px 5px;
+    font-size: 11px;
+    line-height: 10px;
+    color: #cccccc;
+    vertical-align: middle;
+    background-color: #1c1c1c;
+    border: solid 1px #050505;
+    border-bottom-color: #050505;
+    border-radius: 6px;
+    box-shadow: inset 0 -1px 0 #050505;
+}
+
+* {
+	-webkit-print-color-adjust: exact;
+}
+
+@media screen and (min-width: 914px) {
+    body {
+        width: 854px;
+        margin:0 auto;
+    }
+}
+
+@media print {
+	table, pre {
+		page-break-inside: avoid;
+	}
+	pre {
+		word-wrap: break-word;
+	}
+    body {
+        padding: 2cm; 
+    }
+}
+


### PR DESCRIPTION
"GitHub Tomorrow" is a preview-pane theme that combines the basic formatting of the GitHub preview-pane theme with the colors of the Tomorrow edit-pane theme. I created this because there was no dark-mode preview-pane theme that looked nice with the Tomorrow+ edit-pane theme. The preview-pane background color is slightly lighter than the edit-pane background color in order to provide contrast with Tomorrow-themed inline code blocks.

I tested this *somewhat*, and it seems to work, though I ran into several limitations with the rendering engine:

* `::selection { background-color }` does not work as expected (the rendered color is incorrect).
* `li::before { ... }` does not seem to be recognized at all.
* `a code, a tt { text-decoration: none; }` does not seem to be recognized.

Please do let me know if there’s anything you’d like me to change in order for this to be merged. Thanks!