### PR TITLE
printing code with overflow

### DIFF
--- a/MacDown/Resources/Styles/GitHub2.css
+++ b/MacDown/Resources/Styles/GitHub2.css
@@ -308,7 +308,15 @@ kbd {
 	}
 	pre {
 		word-wrap: break-word;
+		white-space: pre-wrap !important;
+		overflow-wrap: break-word;
 	}
+	code, tt {
+		white-space: pre-wrap !important;
+		word-break: break-all;
+		overflow-wrap: break-word;
+	}
+
   body {
     padding: 2cm; 
   }


### PR DESCRIPTION
before in PDF
<img width="734" height="340" alt="Screenshot_2025-08-05_at_14_05_11" src="https://github.com/user-attachments/assets/5a1cbecb-2333-4e87-b4cf-b5bf9d34caa2" />

after (in PDF):

<img width="869" height="537" alt="Screenshot_2025-08-05_at_14_06_25" src="https://github.com/user-attachments/assets/7efa4c01-3645-4db1-8190-e5a48c8b4f82" />
