### PR TITLE
Fix hang on launch caused by out-of-bounds array reads in MPToolbarController

### DIFF
--- a/MacDown/Code/Application/MPToolbarController.m
+++ b/MacDown/Code/Application/MPToolbarController.m
@@ -133,8 +133,10 @@ static CGFloat itemWidth = 37;
     NSMutableArray *defaultItemIdentifiers = [NSMutableArray new];
     
     // Add space after the specified toolbar item indices
-    int spaceAfterIndices[] = {}; // No space in the default set
+    int spaceAfterIndices[] = {-1}; // No space in the default set
+    int spaceAfterIndicesCount = 0;
     int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 11};
+    int flexibleSpaceAfterIndicesCount = (int)(sizeof(flexibleSpaceAfterIndices)/sizeof(flexibleSpaceAfterIndices[0]));
     int i = 0;
     int j = 0;
     int k = 0;
@@ -150,13 +152,13 @@ static CGFloat itemWidth = 37;
             [defaultItemIdentifiers addObject:itemIdentifier];
         }
         
-        if (i == spaceAfterIndices[j])
+        if (j < spaceAfterIndicesCount && i == spaceAfterIndices[j])
         {
             [defaultItemIdentifiers addObject:NSToolbarSpaceItemIdentifier];
             j++;
         }
-        
-        if (i == flexibleSpaceAfterIndices[k])
+
+        if (k < flexibleSpaceAfterIndicesCount && i == flexibleSpaceAfterIndices[k])
         {
             [defaultItemIdentifiers addObject:NSToolbarFlexibleSpaceItemIdentifier];
             k++;


### PR DESCRIPTION
## Summary

On recent Xcode / clang toolchains, MacDown hangs on launch (100% CPU, no window appears) inside `-[MPToolbarController toolbarDefaultItemIdentifiers:]`.

The cause is undefined behavior in that method:

- `int spaceAfterIndices[] = {};` declares a zero-length array, but the loop reads `spaceAfterIndices[j]` unconditionally.
- `int flexibleSpaceAfterIndices[] = {2, 3, 5, 7, 11};` (size 5) is also read as `flexibleSpaceAfterIndices[k]` without checking that `k` is still in range.

On older toolchains the out-of-bounds reads happened to return values that didn't match `i`, so the bug was latent. With newer compilers/optimizers the reads return values that keep matching `i`, causing `j` / `k` to increment past the array bounds and the loop to spin forever appending to `defaultItemIdentifiers`.

## Fix

Track an explicit count for each array and bounds-check `j` and `k` before indexing. No behavior change in the well-defined case.

## Test plan

- [x] Build Release on Xcode 26 / macOS 26 SDK
- [x] Launch the resulting `MacDown.app` — main window appears immediately instead of hanging
- [x] Toolbar default items render as expected (flexible spaces in the same positions)